### PR TITLE
Carbon 15659: Changing carbon-deployment to work with the new carbon.xml config for workers' proxy port

### DIFF
--- a/components/webapp-mgt/org.wso2.carbon.application.mgt.webapp/src/main/java/org/wso2/carbon/application/mgt/webapp/WarApplicationAdmin.java
+++ b/components/webapp-mgt/org.wso2.carbon.application.mgt.webapp/src/main/java/org/wso2/carbon/application/mgt/webapp/WarApplicationAdmin.java
@@ -148,11 +148,11 @@ public class WarApplicationAdmin extends AbstractAdmin {
                 int httpPort = -1;
                 String workerHttpPortString = ServerConfiguration.getInstance().
                         getFirstProperty("Ports.WorkerHttpProxyPort");
-                if(workerHttpPortString != null) {
+                if (workerHttpPortString != null) {
                     httpPort = Integer.parseInt(workerHttpPortString);
                 }
 
-                if(httpPort == -1) {
+                if (httpPort == -1) {
                     httpPort = CarbonUtils.getTransportProxyPort(getConfigContext(), "http");
                 }
 

--- a/components/webapp-mgt/org.wso2.carbon.application.mgt.webapp/src/main/java/org/wso2/carbon/application/mgt/webapp/WarApplicationAdmin.java
+++ b/components/webapp-mgt/org.wso2.carbon.application.mgt.webapp/src/main/java/org/wso2/carbon/application/mgt/webapp/WarApplicationAdmin.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.application.deployer.CarbonApplication;
 import org.wso2.carbon.application.deployer.config.Artifact;
 import org.wso2.carbon.application.deployer.webapp.WARCappDeployer;
 import org.wso2.carbon.application.mgt.webapp.internal.WarAppServiceComponent;
+import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.core.AbstractAdmin;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.webapp.mgt.WebApplication;
@@ -132,7 +133,7 @@ public class WarApplicationAdmin extends AbstractAdmin {
                 String appContext = webApplication.getContextName();
                 for (Container container : webApplication.getContext().findChildren()) {
                     if (((StandardWrapper) container).getServletClass()
-                                                     .equals("org.apache.cxf.transport.servlet.CXFServlet")) {
+                            .equals("org.apache.cxf.transport.servlet.CXFServlet")) {
                         appContext += (((StandardWrapper) container).findMappings())[0];
                     }
                 }
@@ -144,7 +145,17 @@ public class WarApplicationAdmin extends AbstractAdmin {
                 warCappMetadata.setWebappFileName(webApplication.getWebappFile().getName());
                 warCappMetadata.setHostName(webApplication.getHostName());
 
-                int httpPort = CarbonUtils.getTransportProxyPort(getConfigContext(), "http");
+                int httpPort = -1;
+                String workerHttpPortString = ServerConfiguration.getInstance().
+                        getFirstProperty("Ports.WorkerHttpProxyPort");
+                if(workerHttpPortString != null) {
+                    httpPort = Integer.parseInt(workerHttpPortString);
+                }
+
+                if(httpPort == -1) {
+                    httpPort = CarbonUtils.getTransportProxyPort(getConfigContext(), "http");
+                }
+
                 if (httpPort == -1) {
                     httpPort = CarbonUtils.getTransportPort(getConfigContext(), "http");
                 }

--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/WebappAdmin.java
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/WebappAdmin.java
@@ -278,11 +278,9 @@ public class WebappAdmin extends AbstractAdmin {
         return getPagedWebapps(pageNumber, getFaultyWebapps(webappSearchString), webappType);
     }
 
-    private WebappsWrapper getPagedWebapps(int pageNumber, Map<String, VersionedWebappMetadata> webapps,
-            String webappType) {
+    private WebappsWrapper getPagedWebapps(int pageNumber, Map<String, VersionedWebappMetadata> webapps, String webappType) {
         List<VersionedWebappMetadata> webappsList = new ArrayList<VersionedWebappMetadata>(webapps.values());
-        Map<String, WebApplicationsHolder> webApplicationsHolderMap = WebAppUtils
-                .getAllWebappHolders(getConfigContext());
+        Map<String, WebApplicationsHolder> webApplicationsHolderMap = WebAppUtils.getAllWebappHolders(getConfigContext());
         WebappsWrapper webappsWrapper = getWebappsWrapper(webApplicationsHolderMap, webappsList, webappType);
         try {
             webappsWrapper.setHostName(NetworkUtils.getLocalHostname());
@@ -290,44 +288,45 @@ public class WebappAdmin extends AbstractAdmin {
             log.error("Error occurred while getting local hostname", e);
         }
 
-        ServerConfiguration serverConfiguration = ServerConfiguration.getInstance();
+        ServerConfiguration serverConfiguration =  ServerConfiguration.getInstance();
 
-        if (getConfigContext().getAxisConfiguration().getTransportIn("http") != null) {
-            String httpProxyPortString = serverConfiguration.getFirstProperty("Ports.WorkerHttpProxyPort");
-            int httpProxyPort = -1;
-            if (httpProxyPortString != null) {
-                httpProxyPort = Integer.parseInt(httpProxyPortString);
-            }
+        String httpProxyPortString = serverConfiguration.getFirstProperty("Ports.WorkerHttpProxyPort");
+        int httpProxyPort = -1;
+        if(httpProxyPortString != null) {
+            httpProxyPort = Integer.parseInt(httpProxyPortString);
+            webappsWrapper.setHttpPort(httpProxyPort);
+        }
 
-            if (httpProxyPort == -1) {
+        if(httpProxyPort == -1) {
+            if (getConfigContext().getAxisConfiguration().getTransportIn("http") != null) {
                 httpProxyPort = CarbonUtils.getTransportProxyPort(getConfigContext(), "http");
-            }
-
-            if (httpProxyPort != -1) {
-                webappsWrapper.setHttpPort(httpProxyPort);
-            } else {
-                int httpPort = CarbonUtils.getTransportPort(getConfigContext(), "http");
-                webappsWrapper.setHttpPort(httpPort);
+                if (httpProxyPort != -1) {
+                    webappsWrapper.setHttpPort(httpProxyPort);
+                } else {
+                    int httpPort = CarbonUtils.getTransportPort(getConfigContext(), "http");
+                    webappsWrapper.setHttpPort(httpPort);
+                }
             }
         }
 
-        if (getConfigContext().getAxisConfiguration().getTransportIn("https") != null) {
-            String httpsProxyPortString = serverConfiguration.getFirstProperty("Ports.WorkerHttpsProxyPort");
-            int httpsProxyPort = -1;
+        String httpsProxyPortString = serverConfiguration.getFirstProperty("Ports.WorkerHttpsProxyPort");
+        int httpsProxyPort = -1;
 
-            if (httpsProxyPortString != null) {
-                httpsProxyPort = Integer.parseInt(httpsProxyPortString);
-            }
+        if(httpsProxyPortString != null) {
+            httpsProxyPort = Integer.parseInt(httpsProxyPortString);
+            webappsWrapper.setHttpsPort(httpsProxyPort);
+        }
 
-            if (httpsProxyPort == -1) {
+        if(httpsProxyPort == -1) {
+            if (getConfigContext().getAxisConfiguration().getTransportIn("https") != null) {
                 httpsProxyPort = CarbonUtils.getTransportProxyPort(getConfigContext(), "https");
-            }
 
-            if (httpsProxyPort != -1) {
-                webappsWrapper.setHttpsPort(httpsProxyPort);
-            } else {
-                int httpsPort = CarbonUtils.getTransportPort(getConfigContext(), "https");
-                webappsWrapper.setHttpsPort(httpsPort);
+                if (httpsProxyPort != -1) {
+                    webappsWrapper.setHttpsPort(httpsProxyPort);
+                } else {
+                    int httpsPort = CarbonUtils.getTransportPort(getConfigContext(), "https");
+                    webappsWrapper.setHttpsPort(httpsPort);
+                }
             }
         }
 

--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/WebappAdmin.java
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/WebappAdmin.java
@@ -288,16 +288,16 @@ public class WebappAdmin extends AbstractAdmin {
             log.error("Error occurred while getting local hostname", e);
         }
 
-        ServerConfiguration serverConfiguration =  ServerConfiguration.getInstance();
+        ServerConfiguration serverConfiguration = ServerConfiguration.getInstance();
 
         String httpProxyPortString = serverConfiguration.getFirstProperty("Ports.WorkerHttpProxyPort");
         int httpProxyPort = -1;
-        if(httpProxyPortString != null) {
+        if (httpProxyPortString != null) {
             httpProxyPort = Integer.parseInt(httpProxyPortString);
             webappsWrapper.setHttpPort(httpProxyPort);
         }
 
-        if(httpProxyPort == -1) {
+        if (httpProxyPort == -1) {
             if (getConfigContext().getAxisConfiguration().getTransportIn("http") != null) {
                 httpProxyPort = CarbonUtils.getTransportProxyPort(getConfigContext(), "http");
                 if (httpProxyPort != -1) {
@@ -312,12 +312,12 @@ public class WebappAdmin extends AbstractAdmin {
         String httpsProxyPortString = serverConfiguration.getFirstProperty("Ports.WorkerHttpsProxyPort");
         int httpsProxyPort = -1;
 
-        if(httpsProxyPortString != null) {
+        if (httpsProxyPortString != null) {
             httpsProxyPort = Integer.parseInt(httpsProxyPortString);
             webappsWrapper.setHttpsPort(httpsProxyPort);
         }
 
-        if(httpsProxyPort == -1) {
+        if (httpsProxyPort == -1) {
             if (getConfigContext().getAxisConfiguration().getTransportIn("https") != null) {
                 httpsProxyPort = CarbonUtils.getTransportProxyPort(getConfigContext(), "https");
 


### PR DESCRIPTION
Please refer https://wso2.org/jira/browse/CARBON-15659

Even with a kernel version which doesn't have the worker proxy port in carbon.xml, this shouldn't break anything because if the woker proxy port configuration is not present the flow continues as it does without this change. 