### PR TITLE
fixing release:perform failure occurred due to unmappable character in comments

### DIFF
--- a/components/webapp-mgt/org.wso2.carbon.discovery.cxf/src/main/java/org/wso2/carbon/discovery/cxf/listeners/TomcatCxfDiscoveryListener.java
+++ b/components/webapp-mgt/org.wso2.carbon.discovery.cxf/src/main/java/org/wso2/carbon/discovery/cxf/listeners/TomcatCxfDiscoveryListener.java
@@ -314,7 +314,7 @@ public class TomcatCxfDiscoveryListener implements LifecycleListener {
     /**
      * Generate targetNamespace as per jax-ws 2.2 specification chapter 3.2.
      *
-     * 1. The package name is tokenize using the “.” character as a delimiter.
+     * 1. The package name is tokenize using the "." character as a delimiter.
      * 2. The order of the tokens is reversed.
      * 3. The value of the targetNamespace attribute is obtained by concatenating "http://"
      * to the list of tokens separated by "." and "/".


### PR DESCRIPTION
An error occurred while performing release:perform due to error below:
TomcatCxfDiscoveryListener.java:317: error: unmappable character for encoding ANSI_X3.4-1968
The package name is tokenize using the ???.??? character as a delimiter.