### PR TITLE
Referring to CarbonUtils.getCarbonConfigDir and Retrieve carbon.config.dir.path if set

### DIFF
--- a/components/javaee/org.wso2.carbon.javaee.tomee.patch/src/main/java/org/apache/tomee/catalina/OpenEJBContextConfig.java
+++ b/components/javaee/org.wso2.carbon.javaee.tomee.patch/src/main/java/org/apache/tomee/catalina/OpenEJBContextConfig.java
@@ -58,10 +58,6 @@ import org.apache.tomee.common.NamingUtil;
 import org.apache.tomee.common.ResourceFactory;
 import org.apache.xbean.finder.IAnnotationFinder;
 
-import javax.servlet.ServletContainerInitializer;
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServlet;
-import javax.ws.rs.core.Application;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -72,6 +68,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -82,6 +79,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import javax.servlet.ServletContainerInitializer;
+import javax.servlet.http.HttpServlet;
+import javax.ws.rs.core.Application;
 
 public class OpenEJBContextConfig extends ContextConfig {
 	private static Logger logger = Logger.getInstance(LogCategory.OPENEJB, OpenEJBContextConfig.class);
@@ -105,17 +105,23 @@ public class OpenEJBContextConfig extends ContextConfig {
 
         // ############ START - WSO2 PATCH ############
         //set wso2 maintained web.xml and context.xml
-        String globalWebXml = new File(System.getProperty("carbon.home")).getAbsolutePath() +
-                File.separator + "repository" + File.separator + "conf" + File.separator +
-                "tomcat" + File.separator + "web.xml";
-        String globalContextXml = new File(System.getProperty("carbon.home")).getAbsolutePath() +
-                File.separator + "repository" + File.separator + "conf" + File.separator +
-                "tomcat" + File.separator + "context.xml";
-        this.setDefaultWebXml(globalWebXml);
-        this.setDefaultContextXml(globalContextXml);
+		String carbonConfigPath = System.getProperty("carbon.config.dir.path");
+		String globalWebXml;
+		String globalContextXml;
+		if (carbonConfigPath != null) {
+			globalWebXml = Paths.get(carbonConfigPath, "tomcat", "web.xml").toString();
+			globalContextXml = Paths.get(carbonConfigPath, "tomcat", "context.xml").toString();
+		} else {
+			String tomcatDirPath =
+					Paths.get(System.getProperty("carbon.home"), "repository", "conf", "tomcat").toString();
+			globalWebXml = Paths.get(tomcatDirPath, "web.xml").toString();
+			globalContextXml = Paths.get(tomcatDirPath, "context.xml").toString();
+		}
+		this.setDefaultWebXml(globalWebXml);
+		this.setDefaultContextXml(globalContextXml);
         // ############ END - WSO2 PATCH ############
 
-    }
+        }
 
 	public void finder(final IAnnotationFinder finder, final ClassLoader tmpLoader) {
 		this.finder = finder;

--- a/components/javaee/org.wso2.carbon.javaee.tomee/src/main/java/org/wso2/carbon/javaee/tomee/ASTomEEServerListener.java
+++ b/components/javaee/org.wso2.carbon.javaee.tomee/src/main/java/org/wso2/carbon/javaee/tomee/ASTomEEServerListener.java
@@ -31,7 +31,9 @@ import org.apache.openejb.util.OpenEjbVersion;
 import org.apache.tomee.TomEELogConfigurer;
 import org.apache.tomee.catalina.ServerListener;
 import org.apache.tomee.loader.TomcatHelper;
+import org.wso2.carbon.base.CarbonBaseUtils;
 import org.wso2.carbon.base.ServerConfiguration;
+import org.wso2.carbon.utils.CarbonUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,6 +43,7 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -272,9 +275,7 @@ public class ASTomEEServerListener extends ServerListener {
 	}
 
 	private void readSystemPropertiesConf() {
-		String systemPropertiesPath = new File(System.getProperty("carbon.home")).getAbsolutePath() +
-		                              File.separator + "repository" + File.separator + "conf" + File.separator +
-		                              "tomee" + File.separator + "system.properties";
+		String systemPropertiesPath = Paths.get(CarbonUtils.getCarbonConfigDirPath(), "tomee", "system.properties").toString();
 
 		File file = new File(systemPropertiesPath);
 		if (!file.exists()) {

--- a/components/javaee/org.wso2.carbon.javaee.tomee/src/main/java/org/wso2/carbon/javaee/tomee/ASTomcatWebAppBuilder.java
+++ b/components/javaee/org.wso2.carbon.javaee.tomee/src/main/java/org/wso2/carbon/javaee/tomee/ASTomcatWebAppBuilder.java
@@ -30,11 +30,12 @@ import org.apache.tomee.catalina.TomcatWebAppBuilder;
 import org.apache.tomee.common.UserTransactionFactory;
 import org.apache.tomee.loader.TomcatHelper;
 import org.wso2.carbon.tomcat.ext.scan.CarbonTomcatJarScanner;
+import org.wso2.carbon.utils.CarbonUtils;
 
-import javax.servlet.ServletContext;
-import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Paths;
+import javax.servlet.ServletContext;
 
 public class ASTomcatWebAppBuilder extends TomcatWebAppBuilder {
 
@@ -170,12 +171,9 @@ public class ASTomcatWebAppBuilder extends TomcatWebAppBuilder {
             }
         }
         //set default web.xml and context.xml
-        String globalWebXml = new File(System.getProperty("carbon.home")).getAbsolutePath() +
-                File.separator + "repository" + File.separator + "conf" + File.separator +
-                "tomcat" + File.separator + "web.xml";
-        String globalContextXml = new File(System.getProperty("carbon.home")).getAbsolutePath() +
-                File.separator + "repository" + File.separator + "conf" + File.separator +
-                "tomcat" + File.separator + "context.xml";
+        String carbonConfigPath = CarbonUtils.getCarbonConfigDirPath();
+        String globalWebXml = Paths.get(carbonConfigPath, "tomcat", "web.xml").toString();
+        String globalContextXml = Paths.get(carbonConfigPath, "tomcat", "context.xml").toString();
         ContextConfig contextConfig = new ASOpenEJBContextConfig(new StandardContextInfo(standardContext));
         contextConfig.setDefaultWebXml(globalWebXml);
         contextConfig.setDefaultContextXml(globalContextXml);

--- a/components/javaee/org.wso2.carbon.javaee.tomee/src/main/java/org/wso2/carbon/javaee/tomee/scan/ASTomEEJarScanner.java
+++ b/components/javaee/org.wso2.carbon.javaee.tomee/src/main/java/org/wso2/carbon/javaee/tomee/scan/ASTomEEJarScanner.java
@@ -22,6 +22,7 @@ import org.apache.tomcat.util.res.StringManager;
 import org.apache.tomcat.util.scan.Constants;
 import org.apache.tomee.loader.TomEEJarScanner;
 import org.eclipse.osgi.framework.adaptor.BundleClassLoader;
+import org.wso2.carbon.utils.CarbonUtils;
 
 import javax.servlet.ServletContext;
 import java.io.File;
@@ -31,6 +32,7 @@ import java.net.JarURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.Paths;
 import java.util.Set;
 
 /**
@@ -44,8 +46,7 @@ public class ASTomEEJarScanner extends TomEEJarScanner {
     private static final StringManager sm =
             StringManager.getManager(Constants.Package);
 
-    private static final String CARBON_PLUGINS_DIR_PATH = System.getProperty("carbon.home") +
-            File.separator +"repository" + File.separator + "components" + File.separator + "plugins";
+    private static final String CARBON_PLUGINS_DIR_PATH = Paths.get(CarbonUtils.getComponentsRepo()).toString();
 
 
     @Override

--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/loader/CarbonWebappClassLoader.java
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/loader/CarbonWebappClassLoader.java
@@ -1,13 +1,13 @@
 /*
  * Copyright (c) 2005-2012, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- * 
+ *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -20,12 +20,13 @@ package org.wso2.carbon.webapp.mgt.loader;
 import org.apache.catalina.loader.WebappClassLoader;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.utils.CarbonUtils;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
@@ -46,9 +47,7 @@ public class CarbonWebappClassLoader extends WebappClassLoader {
 
     public CarbonWebappClassLoader(ClassLoader parent) {
         super(parent);
-
-        String launchIniPath = System.getProperty("carbon.home") + File.separator + "repository" +
-                File.separator + "conf" + File.separator + "etc" + File.separator + "launch.ini";
+        String launchIniPath = Paths.get(CarbonUtils.getCarbonConfigDirPath(), "etc", "launch.ini").toString();
         readSystemPackagesList(launchIniPath);
     }
 

--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/loader/ClassloadingContextBuilder.java
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/loader/ClassloadingContextBuilder.java
@@ -1,13 +1,13 @@
 /*
  * Copyright (c) 2005-2012, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- * 
+ *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -25,6 +25,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.wso2.carbon.core.util.Utils;
+import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.webapp.mgt.WebappsConstants;
 import org.wso2.carbon.webapp.mgt.utils.XMLUtils;
 
@@ -34,7 +35,11 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.*;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.StringTokenizer;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
@@ -48,13 +53,9 @@ public class ClassloadingContextBuilder {
     public synchronized static ClassloadingConfiguration buildSystemConfig() throws Exception {
         ClassloadingConfiguration classloadingConfig = new ClassloadingConfiguration();
 
-        String carbonHome = System.getProperty(WebappsConstants.CARBON_HOME);
-
-        String envConfigPath = carbonHome + File.separator + "repository" + File.separator + "conf" +
-                File.separator + "tomcat" + File.separator + LoaderConstants.ENV_CONFIG_FILE;
-
-        String clConfigPath = carbonHome + File.separator + "repository" + File.separator + "conf" +
-                File.separator + "tomcat" + File.separator + LoaderConstants.CL_CONFIG_FILE;
+        String carbonConfigPath = CarbonUtils.getCarbonConfigDirPath();
+        String envConfigPath = Paths.get(carbonConfigPath, "tomcat", LoaderConstants.ENV_CONFIG_FILE).toString();
+        String clConfigPath = Paths.get(carbonConfigPath, "tomcat", LoaderConstants.CL_CONFIG_FILE).toString();
 
         //Loading specified environment from the environment config file.
         File envConfigFile = new File(envConfigPath);


### PR DESCRIPTION
Adding changes to refer directory structure changes done for shared components. To comply with Enterprise Integrator 6.0 release. 

Fixes #248 