### PR TITLE
disabling doclint check for genearted stub classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1202,6 +1202,13 @@
                     <target>1.7</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
This is required in jdk 8 build