### PR TITLE
WSAS-2099: WSO2 AS throwing DuplicateDeploymentID exception

### DIFF
--- a/components/javaee/org.wso2.carbon.javaee.tomee/src/main/java/org/wso2/carbon/javaee/tomee/ASTomEEServerListener.java
+++ b/components/javaee/org.wso2.carbon.javaee.tomee/src/main/java/org/wso2/carbon/javaee/tomee/ASTomEEServerListener.java
@@ -195,7 +195,7 @@ public class ASTomEEServerListener extends ServerListener {
 				// ###### WSO2 START PATCH ###### //
 				setServiceManager(properties);
 				setOpenJPALogFactory();
-				readSystemPropertiesConf();
+				readSystemPropertiesConf(properties);
 				ASTomcatLoader loader = new ASTomcatLoader();
 				loader.initSystemInstance(properties);
 				loader.initialize(properties);
@@ -274,8 +274,9 @@ public class ASTomEEServerListener extends ServerListener {
 		}
 	}
 
-	private void readSystemPropertiesConf() {
-		String systemPropertiesPath = Paths.get(CarbonUtils.getCarbonConfigDirPath(), "tomee", "system.properties").toString();
+    private void readSystemPropertiesConf(Properties properties) {
+        String systemPropertiesPath = Paths.get(CarbonUtils.getCarbonConfigDirPath(), "tomee", "system.properties")
+				.toString();
 
 		File file = new File(systemPropertiesPath);
 		if (!file.exists()) {
@@ -288,7 +289,7 @@ public class ASTomEEServerListener extends ServerListener {
 		} catch (IOException e) {
 			return;
 		}
-
+		properties.putAll(systemProperties);
 		SystemInstance.get().getProperties().putAll(systemProperties);
 	}
 


### PR DESCRIPTION
## Purpose
WSO2 AS throwing DuplicateDeploymentID exception when deploying two WebApps having the same Web Fragment.

## Goals
This issue can be solved according to http://stackoverflow.com/questions/4265762/tomcat-application-cannot-be-deployed-as-it-contains-deployment-ids-error
This happened due to the re-initialization of properties even though we read and set the system.properties file.
This fix is also sent to the 4.6.x branch : https://github.com/wso2/carbon-deployment/pull/246
