### PR TITLE
Remove 'dependentComponentName' from the Carbon-Component header

### DIFF
--- a/components/org.wso2.carbon.deployment.engine/pom.xml
+++ b/components/org.wso2.carbon.deployment.engine/pom.xml
@@ -161,8 +161,7 @@
             requiredService="org.wso2.carbon.deployment.engine.Deployer,
             org.wso2.carbon.deployment.engine.LifecycleListener",
 
-            osgi.service;objectClass="org.wso2.carbon.deployment.engine.DeploymentService";
-            dependentComponentName="carbon-transport-mgt"
+            osgi.service;objectClass="org.wso2.carbon.deployment.engine.DeploymentService"
         </carbon.component>
     </properties>
 


### PR DESCRIPTION
## Purpose
`dependentComponentName="carbon-transport-mgt"` in the  Carbon-Component header of the `pom.xml` of `org.wso2.carbon.deployment.engine` component cause to produce following warn log from the Startup Order Resolver.
```
WARN {org.wso2.carbon.kernel.internal.startupresolver.StartupComponentManager} - Adding a required OSGi service capability to component, but specified startup component is not available, component-name: carbon-transport-mgt and capability-name: org.wso2.carbon.deployment.engine.DeploymentService.

```
This happens since `carbon-transport-mgt` OSGi component (from Carbon Transport) is no longer used/packed.
Fixes https://github.com/wso2/product-sp/issues/333
## Goals
- Eliminate the warn log.

## Approach
- Remove `dependentComponentName="carbon-transport-mgt"` in the  Carbon-Component header of the `pom.xml` of `org.wso2.carbon.deployment.engine` component

## Automation tests
 - Unit tests 
   N/A
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
