### PR TITLE
Fix OSGi package export version to be the project version

### DIFF
--- a/components/org.wso2.carbon.deployment.engine/pom.xml
+++ b/components/org.wso2.carbon.deployment.engine/pom.xml
@@ -146,7 +146,7 @@
         <private.package>org.wso2.carbon.deployment.engine.internal.*,</private.package>
         <export.package>
             !org.wso2.carbon.deployment.engine.internal.*,
-            org.wso2.carbon.deployment.engine.*;version="${carbon.deployment.pkg.export.version}",
+            org.wso2.carbon.deployment.engine.*;version="${project.version}",
         </export.package>
         <import.package>
             org.slf4j.*;version="${slf4j.logging.import.version.range}",

--- a/components/org.wso2.carbon.deployment.notifier/pom.xml
+++ b/components/org.wso2.carbon.deployment.notifier/pom.xml
@@ -152,7 +152,7 @@
         <private.package>org.wso2.carbon.deployment.notifier.internal.*,</private.package>
         <export.package>
             !org.wso2.carbon.deployment.notifier.internal.*,
-            org.wso2.carbon.deployment.notifier.*; version="${carbon.deployment.pkg.export.version}"
+            org.wso2.carbon.deployment.notifier.*; version="${project.version}"
         </export.package>
         <import.package>
             org.slf4j.*;version="${slf4j.logging.import.version.range}",

--- a/pom.xml
+++ b/pom.xml
@@ -403,7 +403,6 @@
 
     <properties>
         <carbon.deployment.version>5.1.9-SNAPSHOT</carbon.deployment.version>
-        <carbon.deployment.pkg.export.version>5.0.0</carbon.deployment.pkg.export.version>
 
         <carbon.kernel.version>5.2.0</carbon.kernel.version>
         <carbon.touchpoint.version>1.1.0</carbon.touchpoint.version>


### PR DESCRIPTION
## Purpose
Resolves #279 

## Approach
- Use `${project.version}` as the package export version
- Remove `<carbon.deployment.pkg.export.version>` property from the parent `pom.xml`

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
