### PR TITLE
Change order of deployment for deployment repos

### DIFF
--- a/components/org.wso2.carbon.deployment.engine/pom.xml
+++ b/components/org.wso2.carbon.deployment.engine/pom.xml
@@ -20,13 +20,13 @@
     <parent>
         <groupId>org.wso2.carbon.deployment</groupId>
         <artifactId>org.wso2.carbon.deployment.parent</artifactId>
-        <version>5.1.10-SNAPSHOT</version>
+        <version>5.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.deployment.engine</artifactId>
-    <version>5.1.10-SNAPSHOT</version>
+    <version>5.2.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>WSO2 Carbon Deployment Engine</name>
     <description>

--- a/components/org.wso2.carbon.deployment.engine/src/main/java/org/wso2/carbon/deployment/engine/internal/RepositoryScanner.java
+++ b/components/org.wso2.carbon.deployment.engine/src/main/java/org/wso2/carbon/deployment/engine/internal/RepositoryScanner.java
@@ -80,12 +80,10 @@ public class RepositoryScanner {
         carbonDeploymentEngine.getDeployers()
                 .values()
                 .forEach(deployer -> {
-                    File deploymentLocation = Utils.resolveFileURL(deployer.getLocation().getPath(),
-                            serverRepo.getPath());
-                    findArtifactsToDeploy(deploymentLocation, deployer.getArtifactType());
-                    deploymentLocation = Utils.resolveFileURL(deployer.getLocation().getPath(),
-                                                              runtimeRepo.getPath());
-                    findArtifactsToDeploy(deploymentLocation, deployer.getArtifactType());
+                    findArtifactsToDeploy(Utils.resolveFileURL(deployer.getLocation().getPath(), runtimeRepo.getPath()),
+                                          deployer.getArtifactType());
+                    findArtifactsToDeploy(Utils.resolveFileURL(deployer.getLocation().getPath(), serverRepo.getPath()),
+                                          deployer.getArtifactType());
                 });
         checkUndeployedArtifacts();
     }

--- a/components/org.wso2.carbon.deployment.notifier/pom.xml
+++ b/components/org.wso2.carbon.deployment.notifier/pom.xml
@@ -20,13 +20,13 @@
     <parent>
         <groupId>org.wso2.carbon.deployment</groupId>
         <artifactId>org.wso2.carbon.deployment.parent</artifactId>
-        <version>5.1.10-SNAPSHOT</version>
+        <version>5.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.deployment.notifier</artifactId>
-    <version>5.1.10-SNAPSHOT</version>
+    <version>5.2.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>WSO2 Carbon Deployment Notifier</name>
     <description>

--- a/components/org.wso2.carbon.deployment.notifier/src/main/java/org/wso2/carbon/deployment/notifier/internal/DeploymentNotifierListenerComponent.java
+++ b/components/org.wso2.carbon.deployment.notifier/src/main/java/org/wso2/carbon/deployment/notifier/internal/DeploymentNotifierListenerComponent.java
@@ -35,7 +35,7 @@ import org.wso2.carbon.kernel.CarbonRuntime;
  * @since 5.0.0
  */
 @Component(
-        name = "DeploymentNotifierListenerComponent",
+        name = "org.wso2.carbon.deployment.notifier.internal.DeploymentNotifierListenerComponent",
         immediate = true
 )
 @SuppressWarnings("unused")

--- a/features/org.wso2.carbon.deployment.engine.feature/pom.xml
+++ b/features/org.wso2.carbon.deployment.engine.feature/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>org.wso2.carbon.deployment</groupId>
         <artifactId>org.wso2.carbon.deployment.parent</artifactId>
-        <version>5.1.10-SNAPSHOT</version>
+        <version>5.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.deployment.engine.feature</artifactId>
-    <version>5.1.10-SNAPSHOT</version>
+    <version>5.2.0-SNAPSHOT</version>
     <packaging>carbon-feature</packaging>
 
     <name>WSO2 Carbon Deployment Engine - Feature</name>

--- a/features/org.wso2.carbon.deployment.notifier.feature/pom.xml
+++ b/features/org.wso2.carbon.deployment.notifier.feature/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>org.wso2.carbon.deployment</groupId>
         <artifactId>org.wso2.carbon.deployment.parent</artifactId>
-        <version>5.1.10-SNAPSHOT</version>
+        <version>5.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.deployment.notifier.feature</artifactId>
-    <version>5.1.10-SNAPSHOT</version>
+    <version>5.2.0-SNAPSHOT</version>
     <packaging>carbon-feature</packaging>
 
     <name>WSO2 Carbon Deployment Notifier - Feature</name>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>org.wso2.carbon.deployment</groupId>
     <artifactId>org.wso2.carbon.deployment.parent</artifactId>
     <packaging>pom</packaging>
-    <version>5.1.10-SNAPSHOT</version>
+    <version>5.2.0-SNAPSHOT</version>
     <name>WSO2 Carbon Deployment - Parent</name>
 
     <modules>
@@ -402,7 +402,7 @@
     </dependencyManagement>
 
     <properties>
-        <carbon.deployment.version>5.1.10-SNAPSHOT</carbon.deployment.version>
+        <carbon.deployment.version>5.2.0-SNAPSHOT</carbon.deployment.version>
 
         <carbon.kernel.version>5.2.0</carbon.kernel.version>
         <carbon.touchpoint.version>1.1.0</carbon.touchpoint.version>

--- a/tests/osgi-tests/pom.xml
+++ b/tests/osgi-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.carbon.deployment</groupId>
         <artifactId>tests</artifactId>
-        <version>5.1.10-SNAPSHOT</version>
+        <version>5.2.0-SNAPSHOT</version>
     </parent>
 
     <name>Carbon Deployment OSGi Tests</name>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>org.wso2.carbon.deployment.parent</artifactId>
         <groupId>org.wso2.carbon.deployment</groupId>
-        <version>5.1.10-SNAPSHOT</version>
+        <version>5.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/test-distribution/pom.xml
+++ b/tests/test-distribution/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.deployment</groupId>
         <artifactId>tests</artifactId>
-        <version>5.1.10-SNAPSHOT</version>
+        <version>5.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
## Purpose
Currently artifacts are deployed in the following order,
1. Artifacts in the `<carbon_home>/deployment/<artifact_type>/` directory (server repo)
2. Then artifacts in the `<carbon_home>/wso2/<runtime>/deployment/<artifact_type>/` directory (runtime repo)

However this order causes some troubles to deployers, 
- When doing artifacts overriding (artifact whipped by WSO2 which is in the 'runtime repo' can be overriden by putting am artifact with the same name to the 'server repo')
- When merging artifacts (e.g. two directory artifacts, main one shipped by WSO2 in the 'runtime repo' and the overriding one provided by the customer which has only the overriding bits)
(Above requirements comes from [Carbon UI Server](https://github.com/wso2/carbon-ui-server))

## Goals
Artifacts in **the 'runtime repo' should be deployed first**, then artifacts in the 'server repo'.

## Approach
- In the `mark` method in the `RepositoryScanner` class, first mark artifacts from the 'runtime repo', then from the 'server repo'.
- Bumps Carbon Deployment version to v5.2.0-SNAPSHOT

## Automation tests
 - Unit tests 
   N/A
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
