### PR TITLE
Avoid http EP getting displayed for a policy-secured proxy

### DIFF
--- a/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt.ui/src/main/resources/web/service-mgt/service_info.jsp
+++ b/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt.ui/src/main/resources/web/service-mgt/service_info.jsp
@@ -260,6 +260,9 @@
                     for (String epr : eprs) {
                         if (epr != null) {
                         	if (epr.contains("http")||epr.contains("https")) {
+                                if (epr.contains("http:") && isSecured) {
+                                    continue;
+                                }
                         		carbonEndpoint =epr;
                         	}
                             %>


### PR DESCRIPTION
## Purpose
>When a proxy is secured with a policy, the http endpoint is also getting displayed. But only https endpoint should be visible.
Resolves the issue : https://wso2.org/jira/browse/ESBJAVA-4207