### PR TITLE
Remove support for deleting services in capp

### DIFF
--- a/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt.ui/src/main/resources/org/wso2/carbon/service/mgt/ui/i18n/Resources.properties
+++ b/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt.ui/src/main/resources/org/wso2/carbon/service/mgt/ui/i18n/Resources.properties
@@ -50,6 +50,7 @@ cannot.get.the.number.of.faulty.services=Cannot get the number of faulty service
 could.not.get.service.parameters=Could not get parameters for service: {0}
 cannot.update.service.parameters=Cannot update service parameters
 cannot.delete.service.groups=Cannot delete service groups. Backend service may be unavailable
+cannot.delete.capp.service=Cannot delete services. Some services are deployed via Capp.
 successfully.deleted.service.groups=Successfully deleted selected service groups. Please refresh this page in a while to see the updated service list.
 cannot.delete.all.non.admin.service.groups=Cannot delete all non-admin service groups. Backend service may be unavailable
 successfully.deleted.all.non.admin.service.groups=Successfully deleted all non-admin service groups

--- a/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt.ui/src/main/resources/web/service-mgt/delete_service_groups_ajaxprocessor.jsp
+++ b/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt.ui/src/main/resources/web/service-mgt/delete_service_groups_ajaxprocessor.jsp
@@ -23,6 +23,8 @@
 <%@ page import="org.wso2.carbon.ui.CarbonUIMessage" %>
 <%@ page import="java.util.ResourceBundle" %>
 <%@ page import="org.wso2.carbon.ui.util.CharacterEncoder" %>
+<%@ page import="org.wso2.carbon.service.mgt.stub.types.carbon.ServiceMetaData" %>
+<%@ page import="org.wso2.carbon.service.mgt.stub.types.carbon.ServiceMetaDataWrapper" %>
 <%
     
     String httpMethod = request.getMethod().toLowerCase();
@@ -63,10 +65,40 @@
 
     try {
         if (deleteAllServiceGroups != null) {
+            ServiceMetaDataWrapper allServices = client.getAllServices("ALL", "", 0);
+            ServiceMetaData[] services = allServices.getServices();
+            for (ServiceMetaData smd : services) {
+                if (smd.getCAppArtifact()) {
+                    CarbonUIMessage
+                            .sendCarbonUIMessage(bundle.getString("cannot.delete.capp.service"), CarbonUIMessage.ERROR,
+                                    request);
+            %>
+            <script>
+                location.href = 'index.jsp?pageNumber=<%=pageNumberInt%>'
+            </script>
+
+            <%
+                    return;
+                }
+            }
             client.deleteAllNonAdminServiceGroups();
             CarbonUIMessage.sendCarbonUIMessage(bundle.getString("successfully.deleted.all.non.admin.service.groups"),
                     CarbonUIMessage.INFO, request);
         } else {
+                for (String s : serviceGroups) {
+                    ServiceMetaData smd = client.getServiceData(s);
+                    if (smd.getCAppArtifact()) {
+                        CarbonUIMessage.sendCarbonUIMessage(bundle.getString("cannot.delete.capp.service"),
+                                CarbonUIMessage.ERROR, request);
+                    %>
+                    <script>
+                        location.href = 'index.jsp?pageNumber=<%=pageNumberInt%>'
+                    </script>
+
+                    <%
+                        return;
+                    }
+                }
             client.deleteServiceGroups(serviceGroups);  //TODO handle the returned boolean value
             CarbonUIMessage.sendCarbonUIMessage(bundle.getString("successfully.deleted.service.groups"),
                     CarbonUIMessage.INFO, request);

--- a/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt.ui/src/main/resources/web/service-mgt/index.jsp
+++ b/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt.ui/src/main/resources/web/service-mgt/index.jsp
@@ -462,10 +462,11 @@ padding:0 10px;
                     <a href="./service_info.jsp?serviceName=<%=Encode.forHtmlAttribute(serviceName)%>"><%=Encode.forHtmlContent(serviceName)%>
                     </a>
                     <% } else { %>
+                    <img src="images/applications.gif"
+                         title='<fmt:message key="capp.service.artifact.text"/>'
+                         alt='<fmt:message key="capp.service.artifact"/>'/>
                     <a href="./service_info.jsp?serviceName=<%=Encode.forHtmlAttribute(serviceName)%>"><%=Encode.forHtmlContent(serviceName)%>
-                        <img src="images/applications.gif"
-                             title='<fmt:message key="capp.service.artifact.text"/>'
-                             alt='<fmt:message key="capp.service.artifact"/>'/> </a>
+                    </a>
                     <% } %>
                 </nobr>
             </td>

--- a/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt/src/main/java/org/wso2/carbon/service/mgt/ServiceAdmin.java
+++ b/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt/src/main/java/org/wso2/carbon/service/mgt/ServiceAdmin.java
@@ -115,6 +115,8 @@ public class ServiceAdmin extends AbstractAdmin implements ServiceAdminMBean {
     public static final String DISABLE_TRY_IT_PARAM = "disableTryIt";
     public static final String DISABLE_DELETION_PARAM = "disableDeletion";
     private static final String AXIS2_SERVICE_TYPE = "axis2";
+    private static final String PROXY_SERVICE_TYPE = "proxy";
+    private static final String DATA_SERVICE_TYPE = "data_service";
 
     private PersistenceFactory pf;
     private ServicePersistenceManager spm;
@@ -2544,22 +2546,26 @@ public class ServiceAdmin extends AbstractAdmin implements ServiceAdminMBean {
 
     private boolean isAxisServiceCApp(AxisService axisService) {
         //Check if Service is deployed from a CApp
-        if (AXIS2_SERVICE_TYPE.equals(getServiceType(axisService))) {
-            try {
-                Path axis2ServiceAppPath = Paths.get(axisService.getFileName().toURI());
-                if (axis2ServiceAppPath != null) {
-                    String tenantId = AppDeployerUtils.getTenantIdString();
-                    // Check whether there is an application in the system from the given name
-                    ArrayList<CarbonApplication> appList = DataHolder.getApplicationManager().getCarbonApps(tenantId);
-                    for (CarbonApplication application : appList) {
-                        Path cappPath = Paths.get(application.getExtractedPath());
-                        if (axis2ServiceAppPath.startsWith(cappPath)) {
-                            return true;
+        if (AXIS2_SERVICE_TYPE.equals(getServiceType(axisService)) || PROXY_SERVICE_TYPE
+                .equals(getServiceType(axisService)) || DATA_SERVICE_TYPE.equals(getServiceType(axisService))) {
+            URL fileName = axisService.getFileName();
+            if (fileName != null) {
+                try {
+                    Path axis2ServiceAppPath = Paths.get(fileName.toURI());
+                    if (axis2ServiceAppPath != null) {
+                        String tenantId = AppDeployerUtils.getTenantIdString();
+                        // Check whether there is an application in the system from the given name
+                        ArrayList<CarbonApplication> appList = DataHolder.getApplicationManager().getCarbonApps(tenantId);
+                        for (CarbonApplication application : appList) {
+                            Path cappPath = Paths.get(application.getExtractedPath());
+                            if (axis2ServiceAppPath.startsWith(cappPath)) {
+                                return true;
+                            }
                         }
                     }
+                } catch (URISyntaxException e) {
+                    log.error("Unable to retrieve CApp file path ", e);
                 }
-            } catch (URISyntaxException e) {
-                log.error("Unable to retrieve CApp file path ", e);
             }
         }
         return false;


### PR DESCRIPTION
## Purpose
> Currently the proxy services deployed via a capp can be deleted. This fix removes the support for that.
Fixes the issue: https://wso2.org/jira/browse/ESBJAVA-4139

## Approach
> Made small modification to the logic written to identify whether a service is coming from a capp. Then checking, before sending the services to be deleted, whether there are any services deployed via a capp.

