### PR TITLE
Allow to override ACS url and SSO Skip URIs

### DIFF
--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/sso/SSOUtils.java
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/sso/SSOUtils.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.webapp.mgt.sso;
 
+import org.apache.catalina.connector.Request;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -27,6 +29,8 @@ import java.util.Properties;
 public class SSOUtils {
 
     private static Log log = LogFactory.getLog(SSOUtils.class);
+
+
 
     public static boolean isSSOSPConfigExists() {
         File configFile = new File(WebappSSOConstants.SSO_SP_CONFIG_PATH);
@@ -41,13 +45,55 @@ public class SSOUtils {
         return issuerId;
     }
 
-    public static String generateConsumerUrl(String contextPath, Properties ssoSPConfigProperties) {
-        return ssoSPConfigProperties.getProperty(WebappSSOConstants.APP_SERVER_URL) + contextPath +
-                ssoSPConfigProperties.getProperty(WebappSSOConstants.CONSUMER_URL_POSTFIX);
-    }
-
     public static String getSAMLSSOURLforApp(String requestURI, Properties ssoSPConfigProperties) {
         return ssoSPConfigProperties.getProperty(WebappSSOConstants.APP_SERVER_URL) + requestURI +
                 ssoSPConfigProperties.getProperty(WebappSSOConstants.SAMLSSOURL);
+    }
+
+    /**
+     * By default this method generates the ACS url based on the application server hostname + tenant.suffix. But, in
+     * case the request contains a custom HTTP header containing a different ACS url, this method will honor that url.
+     * (This kind of a scenario can happen when the end user is hoping to access a web application with a custom
+     * domain and URI through a router like Nginx.)
+     * @param request request object
+     * @param ssoSPConfigProperties SSO properties loaded from server level sso-sp-config.properties file.
+     * @return appropriate ACS url
+     */
+    static String generateConsumerUrl(Request request, Properties ssoSPConfigProperties) {
+
+        String assertionConsumerURL = request.getHeader(ssoSPConfigProperties.getProperty(WebappSSOConstants
+                .CUSTOM_ACS_HEADER));
+
+        if (StringUtils.isBlank(assertionConsumerURL)) {
+            assertionConsumerURL = ssoSPConfigProperties.getProperty(WebappSSOConstants.APP_SERVER_URL) + request.getContextPath() +
+                    ssoSPConfigProperties.getProperty(WebappSSOConstants.CONSUMER_URL_POSTFIX);
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Setting ACS_URL to : " + assertionConsumerURL);
+        }
+
+        return assertionConsumerURL;
+    }
+
+    /**
+     * In case an end user wishes to access a web application from a custom domain without any tenant awareness by
+     * fronting the application server with a router like Nginx, we need to detect such a scenario and remove the
+     * tenant component from all redirect URIs during the SSO flow.
+     * @param uri original URI path
+     * @param customACSUrl a custom HTTP header containing a different ACS url
+     * @param tenantName Name of tenant that owns the web application.
+     * @return
+     */
+    static String removeTenantFromURI(String uri, String customACSUrl, String tenantName) {
+
+        String returnURI = uri;
+
+        if (!StringUtils.isBlank(customACSUrl) && !StringUtils.isBlank(tenantName) && !customACSUrl.contains(tenantName)) {
+            returnURI = returnURI.replace(WebappSSOConstants.TENANT_URL_PREFIX + tenantName +
+                    WebappSSOConstants.WEBAPP_PREFIX,"");
+        }
+
+        return returnURI;
     }
 }

--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/sso/SSOUtils.java
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/sso/SSOUtils.java
@@ -30,8 +30,6 @@ public class SSOUtils {
 
     private static Log log = LogFactory.getLog(SSOUtils.class);
 
-
-
     public static boolean isSSOSPConfigExists() {
         File configFile = new File(WebappSSOConstants.SSO_SP_CONFIG_PATH);
         return configFile.exists();
@@ -59,7 +57,7 @@ public class SSOUtils {
      * @param ssoSPConfigProperties SSO properties loaded from server level sso-sp-config.properties file.
      * @return appropriate ACS url
      */
-    static String generateConsumerUrl(Request request, Properties ssoSPConfigProperties) {
+    public static String generateConsumerUrl(Request request, Properties ssoSPConfigProperties) {
 
         String assertionConsumerURL = request.getHeader(ssoSPConfigProperties.getProperty(WebappSSOConstants
                 .CUSTOM_ACS_HEADER));
@@ -85,11 +83,12 @@ public class SSOUtils {
      * @param tenantName Name of tenant that owns the web application.
      * @return
      */
-    static String removeTenantFromURI(String uri, String customACSUrl, String tenantName) {
+    public static String removeTenantFromURI(String uri, String customACSUrl, String tenantName) {
 
         String returnURI = uri;
 
-        if (!StringUtils.isBlank(customACSUrl) && !StringUtils.isBlank(tenantName) && !customACSUrl.contains(tenantName)) {
+        if (!StringUtils.isBlank(customACSUrl) && !StringUtils.isBlank(tenantName)
+                && !customACSUrl.contains(tenantName) && !StringUtils.isBlank(returnURI)) {
             returnURI = returnURI.replace(WebappSSOConstants.TENANT_URL_PREFIX + tenantName +
                     WebappSSOConstants.WEBAPP_PREFIX,"");
         }

--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/sso/WebappSSOConstants.java
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/sso/WebappSSOConstants.java
@@ -42,25 +42,25 @@ public class WebappSSOConstants {
     /**
      * Tenant name as specified in web.xml of application.
      */
-    static final String ENABLE_SAML2_SSO_WITH_TENANT = "enable.saml2.sso.with.tenant";
+    public static final String ENABLE_SAML2_SSO_WITH_TENANT = "enable.saml2.sso.with.tenant";
 
     /**
      * URLs that need to be skipped from SSO flow, as configured in web.xml of application.
      */
-    static final String SKIP_URIS = "sso.skip.uris";
+    public static final String SKIP_URIS = "sso.skip.uris";
 
     /**
      * Custom HTTP header that can override the default generated ACS url for a web application.
      */
-    static final String CUSTOM_ACS_HEADER = "CustomACSHeader";
+    public static final String CUSTOM_ACS_HEADER = "CustomACSHeader";
 
     /**
      * Tenant url prefix used by default in application server.
      */
-    static final String TENANT_URL_PREFIX = "/t/";
+    public static final String TENANT_URL_PREFIX = "/t/";
 
     /**
      * Web application prefix used by default in application server.
      */
-    static final String WEBAPP_PREFIX = "/webapps";
+    public static final String WEBAPP_PREFIX = "/webapps";
 }

--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/sso/WebappSSOConstants.java
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/sso/WebappSSOConstants.java
@@ -38,4 +38,29 @@ public class WebappSSOConstants {
     public static String APP_SERVER_URL = "ApplicationServerURL";
 
     public static String CONSUMER_URL_POSTFIX = "SAML.ConsumerUrlPostFix";
+
+    /**
+     * Tenant name as specified in web.xml of application.
+     */
+    static final String ENABLE_SAML2_SSO_WITH_TENANT = "enable.saml2.sso.with.tenant";
+
+    /**
+     * URLs that need to be skipped from SSO flow, as configured in web.xml of application.
+     */
+    static final String SKIP_URIS = "sso.skip.uris";
+
+    /**
+     * Custom HTTP header that can override the default generated ACS url for a web application.
+     */
+    static final String CUSTOM_ACS_HEADER = "CustomACSHeader";
+
+    /**
+     * Tenant url prefix used by default in application server.
+     */
+    static final String TENANT_URL_PREFIX = "/t/";
+
+    /**
+     * Web application prefix used by default in application server.
+     */
+    static final String WEBAPP_PREFIX = "/webapps";
 }


### PR DESCRIPTION
This fix allows

1. The ACS uri to be overrriden if there is an HTTP header present in the request (where the header name is equal to configuration "CustomACSHeader" in the AS_HOME/repository/conf/security/sso-sp-config.properties file.)
2. The SSO Skip URIs to be overridden if there is a context param "sso.skip.uris" present in the webapp web.xml.
3. To replace the tenant URI component (/t/tenant.com/webapps) from the redirect URIs set within the valve.

## Problem : 

Lets say the web applications come under a tenant space (a.com). Now, if you are fronting the application with a load balancer (e.g. Nginx) and a custom domain (custom.mine.com), one would not prefer to see the internal application server url at the browser. For example, if we expect the application url to be "custom.mine.com/foo", we would prefer to not show the original url "appserver.com/t/a.com/foo". 

A normal workaround here would be to configure a URL rewrite at Nginx. But since the SSO flow is designed to go through a few redirects, we need to fix the problem in a different way. 

## High-level Solution : 

The ideal SSO flow can be explained in terms of browser navigation as follows : 

1.  Request - custom.mine.com/foo
    Response - 302 redirect -> identityserver/samlsso + JSESSION cookie with "custom.mine.com" domain and "/foo" path.

2.  Request - identityserver/samlsso
    Response - 302 redirect -> identityserver/commonauth 

3.  Request - identityserver/commonauth 
    Response - 302 redirect -> identityserver/loginPage 

4.  Request - identityserver/loginPage 
    Response - identityserver/loginPage is loaded. 

    ** After entering credentials 
5.  Request - identityserver/commonauth + credentials
    Response - 302 redirect -> identityserver/samlsso

6.  Request - identityserver/samlsso
    Response - temporary identityserver/samlsso page is loaded until redirection to Assertion Consumer url. 

7.  Request - custom.mine.com/foo/acs ** ACS url + JSESSION cookie since it contains the matching domain and path.
    Response - 302 redirect custom.mine.com/foo

## Role of this fix : 

1. Ability to read a Custom Assertion Consumer URL from the request headers : 

    The request header names can be defined by adding the following 2 properties to AS_HOME/repository/conf/security/sso-sp-config.properties file : 

      // When the SSO application is fronted by an external domain, we need to switch the ACS url to that domain. 
      // This header can be added by any load balancer to the incoming first webapp request, 
      // so that the SAMLSSO Valve knows the correct ACS url. 
      CustomACSHeader=x-acs-url
      
   With this, if we set above "x-acs-url" as custom headers in Nginx, the Valve will set the ACS url based on them. 
   
 2. Ability to Skip certain URIs from SSO flow on a per-webapp basis. 
 
   This fix honors any URIs configured under the "sso.skip.uris" context property in a web application's web.xml, and skips such URls from the SSO flow. 
   
   ```xml
   <context-param>
        <param-name>sso.skip.uris</param-name>
        <param-value>/t/a.com/webapps/foo/iamaskipuri</param-value>
   </context-param>
   ```
 ## Other configurations required for the overall scenario to work : 
 
 1. You will need an Nginx route similar to the following : 
 
```yaml
 location /foo/ {
	proxy_pass https://appserver.com/t/a.com/webapps/foo/; #Route to send the request.
	proxy_set_header X-ACS-URL "https://custom.mine.com/foo/acs"; # Custom HTTP Header to communicate the ACS url to appserver. 
	proxy_pass_request_headers      on;	# Instruct Nginx to pass above custom headers. 
	proxy_cookie_domain     appserver.com custom.mine.com; # In order to switch the domain of the cookies in response.
	proxy_cookie_path       /t/a.com/webapps/foo /foo; # In order to switch the path of the cookies in response.
}
```
      
  2. Set the custom assertion URL at the identity service provider.
  
  3. By default the tomcat container does not set a domain to the JSESSION cookie, and this causes the above "proxy_cookie_domain" directive to not be executed in Nginx. So, to enforce the appserver domain, we must add the  sessionCookieDomain="appserver.com" attribute to the context tag in AS_HOME/repository/conf/tomcat/context.xml. 