### PR TITLE
Fix returning unauthorised error with html page when invalid authorization header presents in the token request

### DIFF
--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/filter/AuthorizationHeaderFilter.java
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/filter/AuthorizationHeaderFilter.java
@@ -141,6 +141,6 @@ public class AuthorizationHeaderFilter implements Filter {
     }
 
     private void handleErrorResponse(HttpServletResponse response, int error, String errorMsg) throws IOException {
-        response.sendError(error, errorMsg);
+        response.setStatus(error);
     }
 }


### PR DESCRIPTION
Fix returning unauthorised error with html page when invalid authorization header presents in the token request