### PR TITLE
Upgrade spring5 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1508,7 +1508,7 @@
         <cxf.bundle.version>2.7.16</cxf.bundle.version>
         <cxf.xjc.version>3.2.1</cxf.xjc.version>
         <spring.version>3.2.18.RELEASE</spring.version>
-        <spring5.version>5.1.1.RELEASE</spring5.version>
+        <spring5.version>5.1.2.RELEASE</spring5.version>
         <carbon.cxf.webapp.ext>1.0.1</carbon.cxf.webapp.ext>
         <aopalliance.version>1.0</aopalliance.version>
         <wss4j.version>1.6.18</wss4j.version>


### PR DESCRIPTION
## Purpose
> Upgrading spring core library version avoid known vulnerabilities reported against 5.1.1-RELEASE versions. 

Although technically we are not affected by the reported vulnerability with the current usage of this dependency, this will help us to avoid being flagged in dependency checks.