### PR TITLE
Remove url mapper

### DIFF
--- a/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt.ui/pom.xml
+++ b/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt.ui/pom.xml
@@ -50,10 +50,6 @@
             <groupId>org.wso2.carbon.deployment</groupId>
             <artifactId>org.wso2.carbon.service.mgt.stub</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.commons</groupId>
-            <artifactId>org.wso2.carbon.url.mapper.stub</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/components/service-mgt/axis2-service-mgt/pom.xml
+++ b/components/service-mgt/axis2-service-mgt/pom.xml
@@ -62,16 +62,6 @@
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.commons</groupId>
-            <artifactId>org.wso2.carbon.url.mapper.stub</artifactId>
-	    <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/components/webapp-mgt/org.wso2.carbon.webapp.list.ui/pom.xml
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.list.ui/pom.xml
@@ -52,10 +52,6 @@
             <groupId>org.wso2.carbon.deployment</groupId>
             <artifactId>org.wso2.carbon.webapp.mgt.stub</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.commons</groupId>
-            <artifactId>org.wso2.carbon.url.mapper.stub</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt.ui/pom.xml
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt.ui/pom.xml
@@ -53,10 +53,6 @@
             <artifactId>org.wso2.carbon.webapp.mgt.stub</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.commons</groupId>
-            <artifactId>org.wso2.carbon.url.mapper.stub</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.deployment</groupId>
             <artifactId>org.wso2.carbon.webapp.mgt</artifactId>
         </dependency>

--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/pom.xml
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/pom.xml
@@ -41,10 +41,6 @@
             <artifactId>org.wso2.carbon.tomcat.ext</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.commons</groupId>
-            <artifactId>org.wso2.carbon.url.mapper</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>

--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/DataHolder.java
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/DataHolder.java
@@ -21,7 +21,6 @@ import org.wso2.carbon.core.deployment.DeploymentSynchronizer;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.registry.core.service.TenantRegistryLoader;
 import org.wso2.carbon.tomcat.api.CarbonTomcatService;
-import org.wso2.carbon.url.mapper.HotUpdateService;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.CarbonUtils;
 
@@ -32,7 +31,6 @@ public class DataHolder {
     private static ConfigurationContext serverConfigContext;
     private static RealmService realmService;
     private static CarbonTomcatService carbonTomcatService;
-    private static HotUpdateService hotUpdateService;
     protected static DeploymentSynchronizer deploymentSynchronizerService;
     private static RegistryService registryService;
     private static TenantRegistryLoader tenantRegistryLoader;
@@ -61,14 +59,6 @@ public class DataHolder {
 
     public static CarbonTomcatService getCarbonTomcatService() {
         return DataHolder.carbonTomcatService;
-    }
-
-    public static void setHotUpdateService(HotUpdateService hotUpdateService) {
-        DataHolder.hotUpdateService = hotUpdateService;
-    }
-
-    public static HotUpdateService getHotUpdateService() {
-        return DataHolder.hotUpdateService;
     }
 
     public static void setDeploymentSynchronizerService(

--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/TomcatGenericWebappsDeployer.java
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/TomcatGenericWebappsDeployer.java
@@ -254,18 +254,6 @@ public class TomcatGenericWebappsDeployer {
             Context context = DataHolder.getCarbonTomcatService()
                                         .addWebApp(WebAppUtils.getHost(webappFile.getAbsolutePath()), contextStr,
                                                    webappFile.getAbsolutePath());
-            //deploying web app for url-mapper
-            if (DataHolder.getHotUpdateService() != null) {
-                List<String> hostNames = DataHolder.getHotUpdateService().getMappigsPerWebapp(contextStr);
-                for (String hostName : hostNames) {
-                    CarbonTomcatService carbonTomcatService = DataHolder.getCarbonTomcatService();
-                    Host host = DataHolder.getHotUpdateService().addHost(hostName);
-                    URLMappingHolder.getInstance().putUrlMappingForApplication(hostName, contextStr);
-                    Context contextForHost =
-                            DataHolder.getCarbonTomcatService().addWebApp(host, "/", webappFile.getAbsolutePath());
-                    log.info("Deployed webapp on host: " + contextForHost);
-                }
-            }
 
             Manager manager = context.getManager();
             if (context.getDistributable() && (DataHolder.getCarbonTomcatService().getTomcat().

--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/TomcatUtil.java
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/TomcatUtil.java
@@ -24,7 +24,6 @@ import org.apache.catalina.util.SessionConfig;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.tomcat.api.CarbonTomcatService;
-import org.wso2.carbon.url.mapper.HotUpdateService;
 import org.wso2.carbon.utils.CarbonUtils;
 
 import javax.servlet.SessionTrackingMode;
@@ -93,17 +92,6 @@ public class TomcatUtil {
             appName = contextName;
         }
         return appName;
-    }
-
-    public static Boolean isVirtualHostRequest(String requestedHostName) {
-        Boolean isVirtualHostRequest = false;
-        HotUpdateService hotUpdate = DataHolder.getHotUpdateService();
-        //checking for whether the request is for virtual host or not, if the server installed with url-mappings only.
-        if(hotUpdate != null && requestedHostName.endsWith(hotUpdate.getSuffixOfHost())) {
-            //in case server url from carbon.xml used as a suffix, then localhost request won't get executed here
-            isVirtualHostRequest = true;
-        }
-        return isVirtualHostRequest;
     }
 
     private static void parseSessionCookiesId(Request request) {

--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/WebApplication.java
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/WebApplication.java
@@ -240,14 +240,6 @@ public class WebApplication {
         //reload the context of WebApplication
 
         try {
-            //reload the context of Host
-            handleHotUpdateToHost("reload");
-        } catch (CarbonException e) {
-            log.error("error while reloading context for the hosts", e);
-        }
-
-
-        try {
             bamEnable = getBamEnableFromWebappMetaData();
         } catch (Exception e) {
             log.error("Unable to get bam enable from web app meta data.", e);
@@ -303,8 +295,7 @@ public class WebApplication {
      * @throws CarbonException If an error occurs while stopping this webapp
      */
     public boolean stop() throws CarbonException {
-        //stop the context of Host
-        handleHotUpdateToHost("stop");
+
         //stop the context of WebApplication
         return stop(this.context);
 
@@ -331,8 +322,7 @@ public class WebApplication {
      * @throws CarbonException If an error occurs while starting this webapp
      */
     public boolean start() throws CarbonException {
-        //start context of the Host
-        handleHotUpdateToHost("start");
+
         //start the context of WebApplication
         return start(this.context);
     }
@@ -357,8 +347,7 @@ public class WebApplication {
      * @throws CarbonException If an error occurs while lazy unloading
      */
     public void lazyUnload() throws CarbonException {
-        //lozyunload the context of Host
-        handleHotUpdateToHost("lazyUnload");
+
         //lazyunload the context of WebApplication
         lazyUnload(this.context);
     }
@@ -433,52 +422,11 @@ public class WebApplication {
     }
 
     /**
-     * Doing the start, stop, reload and lazy unload of webapps inside all hosts
-     * respectively when getting request.
-     *
-     * @param nameOfOperation the operation to be performed in oder to hot update the host
-     * @throws CarbonException if errors occurs when hot update the host
-     */
-    private void handleHotUpdateToHost(String nameOfOperation) throws CarbonException {
-        if (DataHolder.getHotUpdateService() != null) {
-          List<String> mappings = URLMappingHolder.getInstance().
-                   getUrlMappingsPerApplication(this.context.getName());
-            Engine engine = DataHolder.getCarbonTomcatService().getTomcat().getEngine();
-            Context hostContext;
-            Host host;
-            for (String hostName : mappings) {
-                host = (Host) engine.findChild(hostName);
-                if(host != null) {
-                    hostContext = (Context)host.findChild("/");
-                    if(hostContext != null) {
-                        if (nameOfOperation.equalsIgnoreCase("start")) {
-                            start(hostContext);
-                        } else if (nameOfOperation.equalsIgnoreCase("stop")) {
-                            stop(hostContext);
-                        } else if (nameOfOperation.equalsIgnoreCase("reload")) {
-                            reload(hostContext);
-                        } else if (nameOfOperation.equalsIgnoreCase("lazyunload")) {
-                            lazyUnload(hostContext);
-                            DataHolder.getHotUpdateService().removeHost(hostName);
-                        } else if (nameOfOperation.equalsIgnoreCase("delete")) {
-                            DataHolder.getHotUpdateService().deleteHost(hostName);
-                        }
-                    }
-
-                }
-
-            }
-
-        }
-    }
-
-    /**
      * Completely delete & destroy this Web application
      *
      * @throws CarbonException If an error occurs while undeploying this webapp
      */
     public void delete() throws CarbonException {
-        handleHotUpdateToHost("delete");
         undeploy();
         if (webappFile.isFile() && !webappFile.delete()) {
             throw new CarbonException("Webapp file " + webappFile + " deletion failed");

--- a/components/webapp-mgt/pom.xml
+++ b/components/webapp-mgt/pom.xml
@@ -63,14 +63,6 @@
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.server</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.commons</groupId>
-            <artifactId>org.wso2.carbon.url.mapper.stub</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.commons</groupId>
-            <artifactId>org.wso2.carbon.url.mapper</artifactId>
-        </dependency>
     </dependencies>
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -338,38 +338,6 @@
                 <artifactId>org.wso2.carbon.discovery.core</artifactId>
                 <version>${carbon.commons.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.commons</groupId>
-                <artifactId>org.wso2.carbon.url.mapper.stub</artifactId>
-                <version>${carbon.commons.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.commons</groupId>
-                <artifactId>org.wso2.carbon.url.mapper</artifactId>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.wso2.carbon</groupId>
-                        <artifactId>org.wso2.carbon.tomcat.ext</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.wso2.carbon</groupId>
-                        <artifactId>org.wso2.carbon.tomcat</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.wso2.carbon</groupId>
-                        <artifactId>org.wso2.carbon.tomcat.patch</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.wso2.carbon</groupId>
-                        <artifactId>org.wso2.carbon.url.mapper.clustermessage</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                </exclusions>
-                <version>${carbon.commons.version}</version>
-            </dependency>
 
             <!-- Carbon Analytics Commons Dependency-->
             <dependency>


### PR DESCRIPTION
## Purpose
>As the url-mapper feature is removed (https://github.com/wso2/carbon-commons/pull/383) from the carbon-commons, we need to remove these references
As we don't have VirtualHost deployment there won't be any impact due to this