### PR TITLE
Changes for OpenSAML3 migration

### DIFF
--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/sso/SAMLSSOValve.java
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/sso/SAMLSSOValve.java
@@ -26,8 +26,8 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpHeaders;
-import org.opensaml.saml2.core.StatusCode;
-import org.opensaml.xml.util.Base64;
+import org.opensaml.saml.saml2.core.StatusCode;
+import net.shibboleth.utilities.java.support.codec.Base64Support;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.identity.sso.agent.SSOAgentConstants;
 import org.wso2.carbon.identity.sso.agent.bean.LoggedInSessionBean;
@@ -253,10 +253,10 @@ public class SAMLSSOValve extends SingleSignOn {
                                 .getProperty(WebappSSOConstants.ENABLE_IDP_SESSION_VALIDATION_BEFORE_LOGOUT, "false"))
                                 && ssoAgentConfig.getSAML2().isPassiveAuthn()) {
 
-                            String saml2ResponseString = new String(Base64.decode(
+                            String saml2ResponseString = new String(Base64Support.decode(
                                     request.getParameter(SSOAgentConstants.SAML2SSO.HTTP_POST_PARAM_SAML2_RESP)),
                                     Charset.forName("UTF-8"));
-                            org.opensaml.saml2.core.Response saml2Response = (org.opensaml.saml2.core.Response) SSOAgentUtils
+                            org.opensaml.saml.saml2.core.Response saml2Response = (org.opensaml.saml.saml2.core.Response) SSOAgentUtils
                                     .unmarshall(saml2ResponseString);
                             String htmlPayload;
                             ssoAgentConfig.getSAML2().setPassiveAuthn(false);
@@ -447,12 +447,12 @@ public class SAMLSSOValve extends SingleSignOn {
         return redirectPath;
     }
 
-    private boolean isNoPassive(org.opensaml.saml2.core.Response response) {
+    private boolean isNoPassive(org.opensaml.saml.saml2.core.Response response) {
 
         return response.getStatus() != null &&
                 response.getStatus().getStatusCode() != null &&
-                response.getStatus().getStatusCode().getValue().equals(StatusCode.RESPONDER_URI) &&
+                response.getStatus().getStatusCode().getValue().equals(StatusCode.RESPONDER) &&
                 response.getStatus().getStatusCode().getStatusCode() != null &&
-                response.getStatus().getStatusCode().getStatusCode().getValue().equals(StatusCode.NO_PASSIVE_URI);
+                response.getStatus().getStatusCode().getStatusCode().getValue().equals(StatusCode.NO_PASSIVE);
     }
 }

--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/sso/SSOCarbonX509Credential.java
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/sso/SSOCarbonX509Credential.java
@@ -18,10 +18,10 @@
 
 package org.wso2.carbon.webapp.mgt.sso;
 
-import org.opensaml.xml.security.credential.Credential;
-import org.opensaml.xml.security.credential.CredentialContextSet;
-import org.opensaml.xml.security.credential.UsageType;
-import org.opensaml.xml.security.x509.X509Credential;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.security.credential.CredentialContextSet;
+import org.opensaml.security.credential.UsageType;
+import org.opensaml.security.x509.X509Credential;
 
 import javax.crypto.SecretKey;
 import java.security.PrivateKey;
@@ -68,7 +68,7 @@ public class SSOCarbonX509Credential implements X509Credential {
         return null;
     }
 
-    public CredentialContextSet getCredentalContextSet() {
+    public CredentialContextSet getCredentialContextSet() {
         // TODO Auto-generated method stub
         return null;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -1293,7 +1293,7 @@
         <carbon.analytics-common.version>5.2.18</carbon.analytics-common.version>
 
         <!-- Carbon Identity version-->
-        <carbon.identity.version>5.15.56-SNAPSHOT</carbon.identity.version>
+        <carbon.identity.version>5.15.62</carbon.identity.version>
         <sso.agent.version>5.3.4</sso.agent.version>
         <entitlement.proxy.version>5.3.1</entitlement.proxy.version>
         <carbon.identity.imp.pkg.version>[5.15.0, 6.0.0)</carbon.identity.imp.pkg.version>
@@ -1325,7 +1325,7 @@
         <neethi.osgi.version.range>[2.0.4.wso2v4, 3.1.0)</neethi.osgi.version.range>
 
         <!-- Rampart Version -->
-        <rampart.wso2.version>1.6.1-wso2v42-SNAPSHOT</rampart.wso2.version>
+        <rampart.wso2.version>1.6.1-wso2v42</rampart.wso2.version>
 
         <opensaml.version>3.3.1.wso2v1</opensaml.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1130,6 +1130,14 @@
                 <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
                 <version>${apache.felix.scr.ds.annotations.version}</version>
             </dependency>
+
+            <!--OpenSAML3 dependencies-->
+            <dependency>
+                <groupId>org.wso2.orbit.org.opensaml</groupId>
+                <artifactId>opensaml</artifactId>
+                <version>${opensaml.version}</version>
+            </dependency>
+            <!--End of OpenSAML3 dependencies-->
         </dependencies>
     </dependencyManagement>
 
@@ -1286,7 +1294,7 @@
 
         <!-- Carbon Identity version-->
         <carbon.identity.version>5.15.17</carbon.identity.version>
-        <sso.agent.version>5.3.3</sso.agent.version>
+        <sso.agent.version>5.3.4</sso.agent.version>
         <entitlement.proxy.version>5.3.1</entitlement.proxy.version>
         <carbon.identity.imp.pkg.version>[5.14.0, 6.0.0)</carbon.identity.imp.pkg.version>
 
@@ -1318,6 +1326,8 @@
 
         <!-- Rampart Version -->
         <rampart.wso2.version>1.6.1-wso2v41</rampart.wso2.version>
+
+        <opensaml.version>3.3.1.wso2v1</opensaml.version>
 
         <libthrift.wso2.version>0.9.2.wso2v1</libthrift.wso2.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1293,10 +1293,10 @@
         <carbon.analytics-common.version>5.2.18</carbon.analytics-common.version>
 
         <!-- Carbon Identity version-->
-        <carbon.identity.version>5.15.17</carbon.identity.version>
+        <carbon.identity.version>5.15.56-SNAPSHOT</carbon.identity.version>
         <sso.agent.version>5.3.4</sso.agent.version>
         <entitlement.proxy.version>5.3.1</entitlement.proxy.version>
-        <carbon.identity.imp.pkg.version>[5.14.0, 6.0.0)</carbon.identity.imp.pkg.version>
+        <carbon.identity.imp.pkg.version>[5.15.0, 6.0.0)</carbon.identity.imp.pkg.version>
 
         <orbit.version.openid4java>0.9.6.wso2v2</orbit.version.openid4java>
 
@@ -1325,7 +1325,7 @@
         <neethi.osgi.version.range>[2.0.4.wso2v4, 3.1.0)</neethi.osgi.version.range>
 
         <!-- Rampart Version -->
-        <rampart.wso2.version>1.6.1-wso2v41</rampart.wso2.version>
+        <rampart.wso2.version>1.6.1-wso2v42-SNAPSHOT</rampart.wso2.version>
 
         <opensaml.version>3.3.1.wso2v1</opensaml.version>
 


### PR DESCRIPTION
## Purpose
- Migration from OpenSAML 2.x to OpenSAML 3.x

## Prerequisites
- https://github.com/wso2/wso2-wss4j/pull/80 - wss4j with embedded OpenSAML2 dependencies.
- https://github.com/wso2/wso2-rampart/pull/101 - rampart with embedded OpenSAML2 dependencies.
- https://github.com/wso2/carbon-identity-framework/pull/2632 - identity framework with conflicting OpenSAML2 dependencies removed.