### PR TITLE
Fix pagination issue in service_groups.jsp in Management Console

### DIFF
--- a/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt.ui/src/main/resources/web/service-mgt/service_groups.jsp
+++ b/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt.ui/src/main/resources/web/service-mgt/service_groups.jsp
@@ -306,7 +306,7 @@
 %>
 
 <carbon:paginator pageNumber="<%=pageNumberInt%>" numberOfPages="<%=numberOfPages%>"
-                  page="index.jsp" pageNumberParameterName="pageNumber"
+                  page="service_groups.jsp" pageNumberParameterName="pageNumber"
                   resourceBundle="org.wso2.carbon.service.mgt.ui.i18n.Resources"
                   prevKey="prev" nextKey="next"
                   parameters="<%=parameters%>"/>
@@ -461,7 +461,7 @@
                           numberOfPages="<%=numberOfPages%>"/>
 <% } %>
 <carbon:paginator pageNumber="<%=pageNumberInt%>" numberOfPages="<%=numberOfPages%>"
-                  page="index.jsp" pageNumberParameterName="pageNumber"
+                  page="service_groups.jsp" pageNumberParameterName="pageNumber"
                   resourceBundle="org.wso2.carbon.service.mgt.ui.i18n.Resources"
                   prevKey="prev" nextKey="next"
                   parameters="<%= parameters%>"/>


### PR DESCRIPTION
## Purpose
This PR fixes the issue where if we have more than 15 data services in "deployed service group(s)" page (https://localhost:9443/carbon/service-mgt/service_groups.jsp) "next" button redirects to active services page (https://localhost:9443/carbon/service-mgt/index.jsp pageNumber=1&serviceTypeFilter=ALL&serviceGroupSearchString=)

Fixes https://github.com/wso2/product-ei/issues/5112

