### PR TITLE
Bump hibernate-validator version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1450,7 +1450,7 @@
         <olingo-odata2.version>1.1.0</olingo-odata2.version>
         <javax.validation.api.version>2.0.1.Final</javax.validation.api.version>
         <faster.xml.classmate.version>1.3.4</faster.xml.classmate.version>
-        <hibernate.validator.version>6.0.17.Final</hibernate.validator.version>
+        <hibernate.validator.version>6.1.7.Final</hibernate.validator.version>
 
         <!-- J2EE Runtime Enviroment -->
         <myfaces.version>2.1.17</myfaces.version>


### PR DESCRIPTION
Related Issues: wso2/product-is#12485
## Purpose
> Bump hibernate-validator version to 6.1.7.Final