### PR TITLE
[4.11.x] Template configs to support web portal securing

### DIFF
--- a/features/webapp-mgt/org.wso2.carbon.webapp.mgt.server.feature/src/main/resources/conf/tomcat/context.xml.j2
+++ b/features/webapp-mgt/org.wso2.carbon.webapp.mgt.server.feature/src/main/resources/conf/tomcat/context.xml.j2
@@ -37,8 +37,8 @@
       allow="{% for ip in web_app.control_access.allow %}{{ip}}{{ "|" if not loop.last}}{% endfor %}"/>
     {% endif %}
 
-    {% if web_app.listener.class_name is defined %}
-    <Listener className="{{web_app.listener.class_name}}" />
-    {% endif %}
+    {% for class_name in web_app.listener.class_name %}
+    <Listener className="{{class_name}}" />
+    {% endfor %}
 
 </Context>

--- a/features/webapp-mgt/org.wso2.carbon.webapp.mgt.server.feature/src/main/resources/conf/tomcat/context.xml.j2
+++ b/features/webapp-mgt/org.wso2.carbon.webapp.mgt.server.feature/src/main/resources/conf/tomcat/context.xml.j2
@@ -1,0 +1,44 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- The contents of this file will be loaded for each web application -->
+<Context useHttpOnly="true" useRelativeRedirects="false">
+
+    <!-- Default set of monitored resources -->
+
+    <Loader className="org.wso2.carbon.webapp.mgt.loader.CarbonWebappLoader"
+            loaderClass="org.wso2.carbon.webapp.mgt.loader.CarbonWebappClassLoader"/>
+
+    <!-- Uncomment this to disable session persistence across Tomcat restarts -->
+    <Manager className="org.wso2.carbon.webapp.mgt.CarbonTomcatSessionManager">
+        <SessionIdGenerator sessionIdLength="128"/>
+    </Manager>
+
+    <!-- Uncomment this to enable Comet connection tacking (provides events
+         on session expiration as well as webapp lifecycle) -->
+    <!--
+    <Valve className="org.apache.catalina.valves.CometConnectionManagerValve" />
+    -->
+
+    {% if web_app.control_access.enable is sameas true %}
+    <Valve className="org.apache.catalina.valves.RemoteAddrValve"
+      allow="{% for ip in web_app.control_access.allow %}{{ip}}{{ "|" if not loop.last}}{% endfor %}"/>
+    {% endif %}
+
+    {% if web_app.listener.class_name is defined %}
+    <Listener className="{{web_app.listener.class_name}}" />
+    {% endif %}
+
+</Context>

--- a/features/webapp-mgt/org.wso2.carbon.webapp.mgt.server.feature/src/main/resources/p2.inf
+++ b/features/webapp-mgt/org.wso2.carbon.webapp.mgt.server.feature/src/main/resources/p2.inf
@@ -2,10 +2,12 @@ instructions.configure = \
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.webapp.mgt.server_${feature.version}/conf/tomcat/webapp-classloading.xml,target:${installFolder}/../../conf/tomcat/webapp-classloading.xml,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.webapp.mgt.server_${feature.version}/conf/tomcat/webapp-classloading-environments.xml,target:${installFolder}/../../conf/tomcat/webapp-classloading-environments.xml,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.webapp.mgt.server_${feature.version}/conf/tomcat/context.xml,target:${installFolder}/../../conf/tomcat/context.xml,overwrite:true);\
+org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.webapp.mgt.server_${feature.version}/conf/tomcat/context.xml.j2,target:${installFolder}/../../conf/tomcat/context.xml.j2,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.webapp.mgt.server_${feature.version}/conf/security/sso-sp-config.properties,target:${installFolder}/../../conf/security/sso-sp-config.properties,overwrite:true);\
 
 instructions.uninstall = \
 org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/../../conf/tomcat/webapp-classloading.xml,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/../../conf/tomcat/webapp-classloading-environments.xml,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/../../conf/tomcat/context.xml,overwrite:true);\
+org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/../../conf/tomcat/context.xml.j2,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/../../conf/security/sso-sp-config.properties,overwrite:true);\


### PR DESCRIPTION
## Purpose

Related issues: https://github.com/wso2/product-apim/issues/11567, https://github.com/wso2/product-apim/issues/11889

This PR adds the following tomcat configurations.

1. Add below config to deployment.toml in order to control access to the all web applications via the allowed IP list only.
```
[web_app.control_access]
enable = true
allow =  ["IP1", "IP2", "IP3"]
```
2. Add below config to deployment.toml in order to configure a custom Tomcat listener.
```
[web_app.listener]
class_name = ["class1", "class2"]
```