### PR TITLE
[4.11.x] Upgrade cxf, spring, and jackson versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1407,7 +1407,7 @@
         <cxf.bundle.version>2.7.16</cxf.bundle.version>
         <cxf.xjc.version>3.2.1</cxf.xjc.version>
         <spring.version>3.2.18.RELEASE</spring.version>
-        <spring5.version>5.1.2.RELEASE</spring5.version>
+        <spring5.version>5.3.15</spring5.version>
         <carbon.cxf.webapp.ext>1.0.1</carbon.cxf.webapp.ext>
         <aopalliance.version>1.0</aopalliance.version>
         <wss4j.version>1.6.18</wss4j.version>
@@ -1453,9 +1453,9 @@
         <commons.beanutils.orbit.version>1.8.0.wso2v1</commons.beanutils.orbit.version>
         <serp.orbit.version>1.14.1.wso2v1</serp.orbit.version>
 
-        <org.apache.cxf.version>3.3.7</org.apache.cxf.version>
-        <com.fasterxml.jackson.version>2.10.5</com.fasterxml.jackson.version>
-        <com.fasterxml.jackson.databind.version>2.10.5</com.fasterxml.jackson.databind.version>
+        <org.apache.cxf.version>3.5.0</org.apache.cxf.version>
+        <com.fasterxml.jackson.version>2.13.1</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.databind.version>2.13.1</com.fasterxml.jackson.databind.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 
         <!-- for maven release process -->


### PR DESCRIPTION
## Purpose
This PR upgrades the following dependencies to the mentioned versions.
- cxf - `3.5.0`
- spring - `5.3.15`
- jackson - `2.13.1`