### PR TITLE
Change operator during string comparison

### DIFF
--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/WebappAdmin.java
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/WebappAdmin.java
@@ -1060,7 +1060,7 @@ public class WebappAdmin extends AbstractAdmin {
 
             String fileName = uploadData.getFileName();
             String version = uploadData.getVersion();
-            if (version != "" && version != null) {
+            if (version != null && !version.equals("")) {
                 if (fileName.contains(".war")) {
                     fileName = fileName.replace(".war", "#" + version + ".war");
                 } else if (fileName.contains(".zip")) {


### PR DESCRIPTION
Using '!=' to compare two strings for inequality actually compares the object references rather than their values. Therefore equals() method is used instead.

