### PR TITLE
Deploy artifacts based on the lexicographical order

### DIFF
--- a/components/org.wso2.carbon.deployment.engine/src/main/java/org/wso2/carbon/deployment/engine/config/DeploymentConfiguration.java
+++ b/components/org.wso2.carbon.deployment.engine/src/main/java/org/wso2/carbon/deployment/engine/config/DeploymentConfiguration.java
@@ -43,6 +43,9 @@ public class DeploymentConfiguration {
     @Element(description = "Deployment notifier config")
     private DeploymentNotifierConfig deploymentNotifier = new DeploymentNotifierConfig();
 
+    @Element(description = "Preserve alphabetical order")
+    private boolean alphabeticalOrder = false;
+
     public DeploymentConfiguration() {
         serverRepositoryLocation = ConfigurationUtils.substituteVariables(serverRepositoryLocation);
         runtimeRepositoryLocation = ConfigurationUtils.substituteVariables(runtimeRepositoryLocation);
@@ -62,6 +65,10 @@ public class DeploymentConfiguration {
 
     public int getUpdateInterval() {
         return updateInterval;
+    }
+
+    public boolean getAlphabeticalOrder() {
+        return alphabeticalOrder;
     }
 
     public DeploymentNotifierConfig getDeploymentNotifier() {

--- a/components/org.wso2.carbon.deployment.engine/src/main/java/org/wso2/carbon/deployment/engine/config/DeploymentConfiguration.java
+++ b/components/org.wso2.carbon.deployment.engine/src/main/java/org/wso2/carbon/deployment/engine/config/DeploymentConfiguration.java
@@ -43,8 +43,8 @@ public class DeploymentConfiguration {
     @Element(description = "Deployment notifier config")
     private DeploymentNotifierConfig deploymentNotifier = new DeploymentNotifierConfig();
 
-    @Element(description = "Preserve alphabetical order")
-    private boolean alphabeticalOrder = false;
+    @Element(description = "Deploy artifacts by lexicographical order")
+    private boolean deployByLexicographicalOrder = false;
 
     public DeploymentConfiguration() {
         serverRepositoryLocation = ConfigurationUtils.substituteVariables(serverRepositoryLocation);
@@ -67,8 +67,8 @@ public class DeploymentConfiguration {
         return updateInterval;
     }
 
-    public boolean getAlphabeticalOrder() {
-        return alphabeticalOrder;
+    public boolean getDeployByLexicographicalOrder() {
+        return deployByLexicographicalOrder;
     }
 
     public DeploymentNotifierConfig getDeploymentNotifier() {

--- a/components/org.wso2.carbon.deployment.engine/src/main/java/org/wso2/carbon/deployment/engine/internal/RepositoryScanner.java
+++ b/components/org.wso2.carbon.deployment.engine/src/main/java/org/wso2/carbon/deployment/engine/internal/RepositoryScanner.java
@@ -127,7 +127,8 @@ public class RepositoryScanner {
     private void findArtifactsToDeploy(File directoryToSearch, ArtifactType type) {
         DeploymentConfiguration deploymentConfiguration = DataHolder.getInstance().getDeploymentConfiguration();
         File[] files = directoryToSearch.listFiles();
-        if(deploymentConfiguration != null && deploymentConfiguration.getAlphabeticalOrder()) {
+        // Sort the files if the deployment configuration is set to deploy by lexicographical order
+        if (deploymentConfiguration != null && deploymentConfiguration.getDeployByLexicographicalOrder()) {
             Arrays.sort(files);
         }
         if (files != null && files.length > 0) {

--- a/components/org.wso2.carbon.deployment.engine/src/main/java/org/wso2/carbon/deployment/engine/internal/RepositoryScanner.java
+++ b/components/org.wso2.carbon.deployment.engine/src/main/java/org/wso2/carbon/deployment/engine/internal/RepositoryScanner.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.deployment.engine.Artifact;
 import org.wso2.carbon.deployment.engine.ArtifactType;
+import org.wso2.carbon.deployment.engine.config.DeploymentConfiguration;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -124,7 +125,11 @@ public class RepositoryScanner {
      * @param type              ArtifactType
      */
     private void findArtifactsToDeploy(File directoryToSearch, ArtifactType type) {
+        DeploymentConfiguration deploymentConfiguration = DataHolder.getInstance().getDeploymentConfiguration();
         File[] files = directoryToSearch.listFiles();
+        if(deploymentConfiguration != null && deploymentConfiguration.getAlphabeticalOrder()) {
+            Arrays.sort(files);
+        }
         if (files != null && files.length > 0) {
             Arrays.asList(files).forEach(
                     file -> {


### PR DESCRIPTION
## Purpose
This PR introduces a new configuration `deployByLexicographicalOrder` under `wso2.artifact.deployment` to deploy artifacts based on the lexicographical order of their filenames.  The default value is `false`.

```yaml
# Deployment configuration parameters
wso2.artifact.deployment:
  deployByLexicographicalOrder: true
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes