### PR TITLE
Update commons-beanutils version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1371,7 +1371,7 @@
         <!--<commons-pool.version>1.5.0.wso2v1</commons-pool.version>-->
         <commons-logging.version>1.1.1</commons-logging.version>
         <commons-collections.version>3.2.2</commons-collections.version>
-        <commons-beanutils.version>1.9.4</commons-beanutils.version>
+        <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-digester.version>2.1</commons-digester.version>
 
         <!-- Equinox dependency versions -->


### PR DESCRIPTION
### Purpose
This PR updates Apache Commons BeanUtils dependency to version 1.11.0, which addresses the issue of allowing access to the `ClassLoader` via the `declaredClass` property of enum objects, by enabling a secure `BeanIntrospector` by default.

### Related Issue
- https://github.com/wso2/product-is/issues/24556
