### PR TITLE
Bump Apache CXF version from 3.6.5 to 3.6.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1447,7 +1447,7 @@
         <commons.beanutils.orbit.version>1.8.0.wso2v1</commons.beanutils.orbit.version>
         <serp.orbit.version>1.14.1.wso2v1</serp.orbit.version>
 
-        <org.apache.cxf.version>3.6.5</org.apache.cxf.version>
+        <org.apache.cxf.version>3.6.8</org.apache.cxf.version>
         <com.fasterxml.jackson.version>2.17.2</com.fasterxml.jackson.version>
         <com.fasterxml.jackson.databind.version>2.17.2</com.fasterxml.jackson.databind.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>


### PR DESCRIPTION
This PR updates the Apache CXF dependency to the latest patch version to address potential bugs and improve stability.

### Changes Made

**Apache CXF:**
- **org.apache.cxf.version**: `3.6.5` → `3.6.8`

Related Issue : https://github.com/wso2/api-manager/issues/3870