### PR TITLE
Update commons-beanutils, commons-fileuploader, and pax-logging to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1444,7 +1444,7 @@
         <saaj.impl.orbit.version>1.3.18.wso2v1</saaj.impl.orbit.version>
         <tomcat.tribes.orbit.version>7.0.34.wso2v1</tomcat.tribes.orbit.version>
         <commons.lang3.version>3.3.2</commons.lang3.version>
-        <commons.beanutils.orbit.version>1.8.0.wso2v1</commons.beanutils.orbit.version>
+        <commons.beanutils.orbit.version>1.11.0.wso2v1</commons.beanutils.orbit.version>
         <serp.orbit.version>1.14.1.wso2v1</serp.orbit.version>
 
         <org.apache.cxf.version>3.6.8</org.apache.cxf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1341,7 +1341,7 @@
         <!--<commons-pool.version>1.5.0.wso2v1</commons-pool.version>-->
         <commons-logging.version>1.1.1</commons-logging.version>
         <commons-collections.version>3.2.2</commons-collections.version>
-        <commons-beanutils.version>1.8.3</commons-beanutils.version>
+        <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-digester.version>2.1</commons-digester.version>
 
         <!-- Equinox dependency versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -1457,7 +1457,7 @@
 
     <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <maven.scr.plugin.version>1.26.0</maven.scr.plugin.version>
-        <pax.logging.api.version>1.10.1</pax.logging.api.version>
+        <pax.logging.api.version>2.3.0</pax.logging.api.version>
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1393,7 +1393,7 @@
         <imp.pkg.version.spring>[3.2.9.wso2v1, 3.3.0)</imp.pkg.version.spring>
         <org.scannotation.version>1.0.3</org.scannotation.version>
 
-        <orbit.version.commons.fileuploader>1.3.3.wso2v1</orbit.version.commons.fileuploader>
+        <orbit.version.commons.fileuploader>1.6.0.wso2v1</orbit.version.commons.fileuploader>
         <orbit.version.woden>1.0.0.M8-wso2v1</orbit.version.woden>
 
         <!-- CXF Runtime Bundles -->


### PR DESCRIPTION
This PR updates several key dependencies to their latest stable versions to improve security, performance, and compatibility.

### Changes Made

**Commons Libraries:**
- **commons-beanutils**: `1.8.0.wso2v1` / `1.8.3` → `1.11.0.wso2v1`
- **commons-fileuploader**: `1.3.3.wso2v1` → `1.6.0.wso2v1`

**Logging Libraries:**
- **pax-logging**: `1.10.1` → `2.3.0`

Related Issue : https://github.com/wso2/api-manager/issues/3870
