### PR TITLE
Update carbon.analytics-common version from 5.3.7 to 5.3.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1290,7 +1290,7 @@
         <carbon.commons.imp.pkg.version>[4.7.0, 5.0.0)</carbon.commons.imp.pkg.version>
 
         <!-- Carbon Analytics Commons version -->
-        <carbon.analytics-common.version>5.3.7</carbon.analytics-common.version>
+        <carbon.analytics-common.version>5.3.27</carbon.analytics-common.version>
 
         <!-- Carbon Identity version-->
         <carbon.identity.version>5.18.0</carbon.identity.version>


### PR DESCRIPTION
This PR updates the Carbon Analytics Common library to its latest stable version to improve security, performance, and compatibility.

### Changes Made

**Carbon Libraries:**
- **carbon.analytics-common**: `5.3.7` → `5.3.27`

Related Issue: https://github.com/wso2/api-manager/issues/3870