### PR TITLE
[4.11.x] Upgrade axis2 and axiom versions

### DIFF
--- a/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt.ui/pom.xml
+++ b/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt.ui/pom.xml
@@ -69,7 +69,7 @@
                         <Carbon-Component>UIBundle</Carbon-Component>
                         <Import-Package>
                             org.wso2.carbon.service.mgt.stub.*;version="${carbon.deployment.imp.pkg.version}",
-                            org.apache.axis2.*; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.*; version="${imp.pkg.version.axis2}",
                             org.apache.axiom.*; version="${axiom.osgi.version.range}",
                             *;resolution:=optional
                         </Import-Package>

--- a/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt/pom.xml
+++ b/components/service-mgt/axis2-service-mgt/org.wso2.carbon.service.mgt/pom.xml
@@ -124,7 +124,7 @@
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Private-Package>org.wso2.carbon.service.mgt.internal</Private-Package>
                         <Import-Package>
-                            org.apache.axis2.*; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.*; version="${imp.pkg.version.axis2}",
                             org.apache.axiom.*; version="${axiom.osgi.version.range}",
                             org.apache.neethi.*; version="${neethi.osgi.version.range}",
                             javax.xml.stream.*; version="1.0.1",

--- a/components/service-mgt/jar-services/org.wso2.carbon.jarservices/pom.xml
+++ b/components/service-mgt/jar-services/org.wso2.carbon.jarservices/pom.xml
@@ -45,7 +45,7 @@
                         </Export-Package>
                         <Import-Package>
                             !org.wso2.carbon.jarservices.*,
-                            org.apache.axis2.*; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.*; version="${imp.pkg.version.axis2}",
                             org.apache.commons.logging.*; version="${import.package.version.commons.logging}",
                             *;resolution:=optional,
                         </Import-Package>

--- a/components/service-mgt/module-mgt/org.wso2.carbon.module.mgt/pom.xml
+++ b/components/service-mgt/module-mgt/org.wso2.carbon.module.mgt/pom.xml
@@ -50,7 +50,7 @@
                             !org.wso2.carbon.module.mgt.service,
                             !org.wso2.carbon.module.mgt,
                             org.apache.neethi.*,
-                            org.apache.axis2.*; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.*; version="${imp.pkg.version.axis2}",
                             org.apache.axiom.*; version="${axiom.osgi.version.range}",
                             javax.xml.stream.*; version="1.0.1",
                             *;resolution:=optional

--- a/components/service-mgt/operation-mgt/org.wso2.carbon.operation.mgt.ui/pom.xml
+++ b/components/service-mgt/operation-mgt/org.wso2.carbon.operation.mgt.ui/pom.xml
@@ -70,7 +70,7 @@
                             org.wso2.carbon.operation.mgt.ui.*,
                         </Export-Package>
                         <Import-Package>
-                            org.apache.axis2.*; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.*; version="${imp.pkg.version.axis2}",
                             org.apache.axiom.*; version="${axiom.osgi.version.range}",
                             javax.servlet;version="${imp.pkg.version.javax.servlet}",
                             javax.servlet.http;version="${imp.pkg.version.javax.servlet}",

--- a/components/service-mgt/operation-mgt/org.wso2.carbon.operation.mgt/pom.xml
+++ b/components/service-mgt/operation-mgt/org.wso2.carbon.operation.mgt/pom.xml
@@ -55,7 +55,7 @@
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Private-Package>org.wso2.carbon.operation.mgt.internal</Private-Package>
                         <Import-Package>
-                            org.apache.axis2.*; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.*; version="${imp.pkg.version.axis2}",
                             org.apache.axiom.*; version="${axiom.osgi.version.range}",
                             org.apache.neethi.*; version="${neethi.osgi.version.range}",
                             javax.xml.stream.*; version="1.0.1",

--- a/components/service-mgt/spring-services/org.wso2.carbon.spring-services/pom.xml
+++ b/components/service-mgt/spring-services/org.wso2.carbon.spring-services/pom.xml
@@ -46,7 +46,7 @@
                         </Export-Package>
                         <Import-Package>
                             !org.wso2.carbon.springservices,
-                            org.apache.axis2.*; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.*; version="${imp.pkg.version.axis2}",
                             org.springframework.*; version="${imp.pkg.version.spring}",
                             *;resolution:=optional
                         </Import-Package>

--- a/components/webapp-mgt/org.wso2.carbon.jaxws.webapp.deployer/pom.xml
+++ b/components/webapp-mgt/org.wso2.carbon.jaxws.webapp.deployer/pom.xml
@@ -44,7 +44,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Import-Package>
-                            org.apache.axis2.*; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.*; version="${imp.pkg.version.axis2}",
                             org.apache.axiom.*; version="${axiom.osgi.version.range}",
                             org.osgi.framework.*,
                             *;resolution:=optional

--- a/components/webapp-mgt/org.wso2.carbon.jaxws.webapp.mgt.ui/pom.xml
+++ b/components/webapp-mgt/org.wso2.carbon.jaxws.webapp.mgt.ui/pom.xml
@@ -63,7 +63,7 @@
                         <Import-Package>
                             !org.wso2.carbon.jaxws.webapp.mgt.ui.*,
                             org.wso2.carbon.webapp.mgt.stub.*;version="${carbon.deployment.imp.pkg.version}",
-                            org.apache.axis2.*; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.*; version="${imp.pkg.version.axis2}",
                             org.apache.axiom.*; version="${axiom.osgi.version.range}",
                             *;resolution:=optional
                         </Import-Package>

--- a/components/webapp-mgt/org.wso2.carbon.jaxws.webapp.mgt/pom.xml
+++ b/components/webapp-mgt/org.wso2.carbon.jaxws.webapp.mgt/pom.xml
@@ -44,7 +44,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Import-Package>
-                            org.apache.axis2.*; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.*; version="${imp.pkg.version.axis2}",
                             org.apache.axiom.*; version="${axiom.osgi.version.range}",
                             org.apache.neethi.*; version="${neethi.osgi.version.range}",
                             org.wso2.carbon.webapp.mgt,

--- a/components/webapp-mgt/org.wso2.carbon.webapp.deployer/pom.xml
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.deployer/pom.xml
@@ -39,7 +39,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Import-Package>
-                            org.apache.axis2.*; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.*; version="${imp.pkg.version.axis2}",
                             org.apache.axiom.*; version="${axiom.osgi.version.range}",
                             org.osgi.framework.*,
                             *;resolution:=optional

--- a/components/webapp-mgt/org.wso2.carbon.webapp.list.ui/pom.xml
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.list.ui/pom.xml
@@ -74,7 +74,7 @@
                         <Import-Package>
                             !org.wso2.carbon.webapp.list.ui.*,
                             org.wso2.carbon.webapp.mgt.stub.*;version="${carbon.deployment.imp.pkg.version}",
-                            org.apache.axis2.*; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.*; version="${imp.pkg.version.axis2}",
                             org.apache.axiom.*; version="${axiom.osgi.version.range}",
                             *;resolution:=optional
                         </Import-Package>

--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt.ui/pom.xml
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt.ui/pom.xml
@@ -81,7 +81,7 @@
                         <Import-Package>
                             !org.wso2.carbon.webapp.mgt.ui.*,
                             org.wso2.carbon.webapp.mgt.stub.*;version="${carbon.deployment.imp.pkg.version}",
-                            org.apache.axis2.*; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.*; version="${imp.pkg.version.axis2}",
                             org.apache.axiom.*; version="${axiom.osgi.version.range}",
                             *;resolution:=optional
                         </Import-Package>

--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/pom.xml
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/pom.xml
@@ -72,7 +72,7 @@
                         <Private-Package>org.wso2.carbon.webapp.mgt.internal</Private-Package>
                         <Import-Package>
                             !org.wso2.carbon.webapp.mgt.*,
-                            org.apache.axis2.*; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.*; version="${imp.pkg.version.axis2}",
                             org.apache.axiom.*; version="${axiom.osgi.version.range}",
                             org.apache.neethi.*; version="${neethi.osgi.version.range}",
                             javax.xml.stream.*; version="1.0.1",

--- a/pom.xml
+++ b/pom.xml
@@ -1313,13 +1313,12 @@
         <!-- Axiom Version -->
         <axiom.wso2.version>${axiom.version}</axiom.wso2.version>
         <orbit.version.axiom>${axiom.version}</orbit.version.axiom>
-        <axiom.version>1.2.11-wso2v29</axiom.version>
+        <axiom.version>1.2.11-wso2v30</axiom.version>
         <axiom.osgi.version.range>[1.2.11, 1.3.0)</axiom.osgi.version.range>
 
         <!-- Axis2 Version -->
-        <axis2.wso2.version>1.6.1-wso2v105</axis2.wso2.version>
-        <axis2.osgi.version.range>[1.6.1-wso2v105, 1.7.0)</axis2.osgi.version.range>
-        <imp.pkg.version.axis2>[1.6.1-wso2v105, 1.7.0)</imp.pkg.version.axis2>
+        <axis2.wso2.version>1.6.1-wso2v108</axis2.wso2.version>
+        <imp.pkg.version.axis2>[1.6.1, 1.7.0)</imp.pkg.version.axis2>
         <orbit.version.axis2>${axis2.wso2.version}</orbit.version.axis2>
         <axis2.wso2.version.aar.plugin>1.6.2</axis2.wso2.version.aar.plugin>
         <neethi.osgi.version>2.0.4.wso2v5</neethi.osgi.version>


### PR DESCRIPTION
## Purpose

This pull request updates the Axis2 and Axiom dependency versions and standardizes the way the Axis2 import package version is referenced across multiple Maven POM files. The changes help ensure consistency and compatibility with the updated versions throughout the codebase.

**Dependency version updates:**

* Updated the Axis2 dependency from `1.6.1-wso2v105` to `1.6.1-wso2v108` and changed the import package version range for Axis2 to `[1.6.1, 1.7.0)` in the root `pom.xml`.
* Updated the Axiom dependency from `1.2.11-wso2v29` to `1.2.11-wso2v30` in the root `pom.xml`.

**Standardization of Axis2 import version:**

* Replaced usage of the property `${axis2.osgi.version.range}` with `${imp.pkg.version.axis2}` for the Axis2 import package version in all affected module POM files, ensuring a single point of configuration for Axis2 versioning. [[1]](diffhunk://#diff-d2165d9650624679a324dc6abd91f15b323a97ff4a25c3326fe92c2696fe9044L72-R72) [[2]](diffhunk://#diff-a7e2f5af83c3e5109436e7cdfd231abf64f13d2cfddb274d6794d12ad7f04e21L127-R127) [[3]](diffhunk://#diff-9f04e3b85740f92439bd4aef42979038a447657ade4654ad9ddcb76daef50586L48-R48) [[4]](diffhunk://#diff-23f9922b2f08bf795588a3938fa5c9c94d48dd708e14036822ef10d86264fb36L53-R53) [[5]](diffhunk://#diff-9a4bb714a04a3bb580671d6ff4a20367a061c187554836d99a12b3a1cfac9b48L73-R73) [[6]](diffhunk://#diff-77c54665c85e181171924ec54a044fa158234c49e379261d653a88b4012ce4ccL58-R58) [[7]](diffhunk://#diff-8a14092a78193d0bc28aa9523eb427db4506e0e1481bc8c2d980a46abc5d8124L49-R49) [[8]](diffhunk://#diff-e81a37ccd95b83d23cbda3b9a91d850b590b4e018ac71573466ee161a13bb521L47-R47) [[9]](diffhunk://#diff-7bd13f6c341dce66b21314333f2c7c85ce925a2d459546ccaed516511b690714L66-R66) [[10]](diffhunk://#diff-b2c24a7ab6c4b32093adfde44015f58dd7575968483e600617443c82354f6395L47-R47) [[11]](diffhunk://#diff-e7b61b7610f6720ac86a09aca9eabb3b38fa633ffdd991f4c42de90d8b91a02bL42-R42) [[12]](diffhunk://#diff-120a7ae694d0089ef6465b78a8733cc65a0c96f27bdd5c0d59857debab96ffbdL77-R77) [[13]](diffhunk://#diff-b6ddcb4ef2c030039aaebf117ed62f03addd7ce663d5f6237c032687388c2686L84-R84) [[14]](diffhunk://#diff-ea24ee212885cffd588559e576a801166bc7116c9e47a598eec21ec5ca049dd0L75-R75)

These changes improve maintainability and reduce the risk of version mismatches for Axis2 dependencies across the project.