### PR TITLE
Improve webapp filename validation regex to include line terminators

### DIFF
--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/utils/WebAppUtils.java
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/utils/WebAppUtils.java
@@ -68,8 +68,8 @@ public class WebAppUtils {
     }
 
     public static boolean validateWebappFileName(String filename) {
-        Pattern pattern = Pattern.compile(".*[\\]\\[!\"$%&'()*+,/:;<=>?@~{|}^`].*");
-        Matcher matcher = pattern.matcher(filename);
+        Pattern pattern = Pattern.compile("(?s).*([\\n\\r]|[\\]\\[!\"$%&'()*+,/:;<=>?@~{|}^`]).*");
+        Matcher matcher = pattern.matcher(filename.trim());
         boolean isMatch = matcher.matches();
         return isMatch;
     }


### PR DESCRIPTION
## Problem
The current validation regex for webapp filenames does not account for line termination characters (\n, \r) in the input string. In Java, the standard . (dot) operator in regular expressions matches any character except line terminators unless specifically configured otherwise.

If a filename input contains a newline character, the validation logic currently evaluates only the segment of the string preceding that character. This can result in partial validation where segments of a multi-line filename bypass the defined character restrictions.

## Solution
The validation logic has been updated to ensure the entire input string is evaluated as a single unit:

The regex pattern has been updated to explicitly include line terminators (\n, \r) as prohibited characters for filenames.

The matching logic has been refined to ensure that the defined "forbidden character set" is checked across the entire length of the input string, regardless of line breaks.

This ensures that a filename must be a single-line, continuous string to be considered valid.
## Verification

<img width="1726" height="912" alt="Screenshot 2026-03-17 at 17 08 10" src="https://github.com/user-attachments/assets/76437464-9a1d-47ba-8dbe-e267e4edf0b7" />
