### PR TITLE
Fix Nexus deployment URL to use HTTPS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,19 @@
         <tag>HEAD</tag>
     </scm>
 
+    <distributionManagement>
+        <repository>
+            <id>nexus-releases</id>
+            <name>WSO2 Nexus Release Repository</name>
+            <url>https://maven.wso2.org/nexus/service/local/staging/deploy/maven2/</url>
+        </repository>
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>WSO2 Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
     <build>
         <extensions>
             <extension>


### PR DESCRIPTION
## Summary
- Nexus no longer allows HTTP uploads, causing the Jenkins release build (v5.2.3) to hang at the `maven-deploy-plugin` stage
- Added `distributionManagement` section to the root `pom.xml` to override the parent POM's HTTP URLs with HTTPS equivalents
- Same fix already applied in the `siddhi` repository

## Test plan
- [ ] Trigger a release build and verify artifacts upload successfully to Nexus over HTTPS
- [ ] Verify snapshot deployments also work with the updated URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build deployment configuration to specify separate targets for release and snapshot artifact distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->