### PR TITLE
[carbon-deployment] Bump Jackson to 2.21.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1491,8 +1491,8 @@
 
         <org.apache.cxf.version>3.5.11</org.apache.cxf.version>
         <xercesImpl.version>2.12.2.wso2v1</xercesImpl.version>
-        <com.fasterxml.jackson.version>2.17.2</com.fasterxml.jackson.version>
-        <com.fasterxml.jackson.databind.version>2.17.2</com.fasterxml.jackson.databind.version>
+        <com.fasterxml.jackson.version>2.21.2</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.databind.version>2.21.2</com.fasterxml.jackson.databind.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 
         <!-- for maven release process -->


### PR DESCRIPTION
## Purpose
Upgrade Jackson Databind and related libraries to the latest stable 2.21.x release.

## Goals
- Align all Jackson artifacts to a consistent 2.21.x baseline across the IS dependency tree
- Replace the 2.17.x versions that are no longer receiving upstream fixes

## Approach
Version property bumps only — no code or logic changes. The following properties were updated in the root `pom.xml`:
- `com.fasterxml.jackson.version` → `2.21.2`
- `com.fasterxml.jackson.databind.version` → `2.21.2`