### PR TITLE
Redeploy webapp on watched-resource change + make it configurable (fix taglib JSP NPE)

### DIFF
--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/AbstractWebappDeployer.java
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/AbstractWebappDeployer.java
@@ -198,7 +198,8 @@ public abstract class AbstractWebappDeployer extends AbstractDeployer {
                                         handleRedeployment(unpackedFile);
                                         log.info("Redeployed context: " + contextName + " (recovered)");
                                     } catch (Exception recoveryError) {
-                                        log.error("Redeploy retry failed for context: " + contextName);
+                                        log.error("Redeploy retry failed for context: " + contextName,
+                                                recoveryError);
                                     }
                                 }
                                 // If redeploy failed to reseed the baseline, restore the previous baseline so the

--- a/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/AbstractWebappDeployer.java
+++ b/components/webapp-mgt/org.wso2.carbon.webapp.mgt/src/main/java/org/wso2/carbon/webapp/mgt/AbstractWebappDeployer.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.CarbonException;
+import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.webapp.mgt.utils.WebAppUtils;
@@ -42,6 +43,12 @@ import java.util.concurrent.ConcurrentHashMap;
 public abstract class AbstractWebappDeployer extends AbstractDeployer {
 
     private static final Log log = LogFactory.getLog(AbstractWebappDeployer.class);
+
+    // carbon.xml property controlling watched-resource reload; defaults to true when absent (preserves
+    // legacy behavior). Unrelated to JSP hot deployment, which Jasper handles independently.
+    private static final String WATCHED_RESOURCE_RELOAD_ENABLED_CONFIG =
+            "WebappManagement.WatchedResourceReloadEnabled";
+
     protected String webappsDir;
     protected String extension;
     protected TomcatGenericWebappsDeployer tomcatWebappDeployer;
@@ -49,6 +56,7 @@ public abstract class AbstractWebappDeployer extends AbstractDeployer {
     protected ConfigurationContext configContext;
     protected Map<String, WebApplicationsHolder> webApplicationsHolderMap;
     private String[] defaultWatchedResources;
+    private boolean watchedResourceReloadEnabled;
     private final Map<String, Long> webappLastWatchedResourceModifiedTimes = new ConcurrentHashMap<String, Long>();
 
     public void init(ConfigurationContext configCtx) {
@@ -84,6 +92,17 @@ public abstract class AbstractWebappDeployer extends AbstractDeployer {
         defaultWatchedResources = new String[]{"WEB-INF" + File.separator + "web.xml",
                 "WEB-INF" + File.separator + "lib",
                 "WEB-INF" + File.separator + "classes"};
+
+        // Enabled by default (absent property -> true) to preserve legacy behavior; set false to stop
+        // the reload that is the spurious trigger on NFS-shared multi-node deployments.
+        String watchedResourceReloadConfig =
+                ServerConfiguration.getInstance().getFirstProperty(WATCHED_RESOURCE_RELOAD_ENABLED_CONFIG);
+        watchedResourceReloadEnabled =
+                (watchedResourceReloadConfig == null) || Boolean.parseBoolean(watchedResourceReloadConfig);
+        if (log.isDebugEnabled()) {
+            log.debug("Watched-resource reload for webapps under '" + webappsDir + "' is "
+                    + (watchedResourceReloadEnabled ? "enabled" : "disabled") + ".");
+        }
     }
 
     protected abstract TomcatGenericWebappsDeployer createTomcatGenericWebappDeployer(
@@ -154,7 +173,7 @@ public abstract class AbstractWebappDeployer extends AbstractDeployer {
                     handleUndeployment(fileName, unpackedFile);
                     handleRedeployment(warFile);
                 }
-            } else {
+            } else if (watchedResourceReloadEnabled) {
                 Context context = getWebappContext(unpackedFile);
                 if (context != null) {
                     synchronized (("webapp-reload-lock:" + context.getName()).intern()) {
@@ -162,10 +181,35 @@ public abstract class AbstractWebappDeployer extends AbstractDeployer {
                             long latestWatchedResourceModifiedTime =
                                     getLatestWatchedResourceModifiedTime(fileName, context);
                             if (isWatchedResourceChanged(context, latestWatchedResourceModifiedTime)) {
-                                // if watchedResources are modified, reload the context
-                                context.reload();
-                                updateWatchedResourceModifiedState(context, latestWatchedResourceModifiedTime);
-                                log.info("Reloaded Context with name: " + context.getName());
+                                // Watched-resource changes require full undeploy+redeploy (not reload)
+                                // so Jasper's TldCache is rebuilt and JSPs recompile correctly. Redeploy
+                                // also reseeds the watched-resource baseline.
+                                String contextName = context.getName();
+                                Long previousWatchedResourceModifiedTime =
+                                        webappLastWatchedResourceModifiedTimes.get(contextName);
+                                handleUndeployment(fileName, unpackedFile);
+                                try {
+                                    handleRedeployment(unpackedFile);
+                                    log.info("Redeployed context: " + contextName);
+                                } catch (Exception redeploymentError) {
+                                    log.error("Redeploy failed for context: " + contextName + ", retrying.",
+                                            redeploymentError);
+                                    try {
+                                        handleRedeployment(unpackedFile);
+                                        log.info("Redeployed context: " + contextName + " (recovered)");
+                                    } catch (Exception recoveryError) {
+                                        log.error("Redeploy retry failed for context: " + contextName);
+                                    }
+                                }
+                                // If redeploy failed to reseed the baseline, restore the previous baseline so the
+                                // next change still triggers redeployment. Do not advance the baseline to the
+                                // failing timestamp.
+                                if (previousWatchedResourceModifiedTime != null &&
+                                        webappLastWatchedResourceModifiedTimes.get(contextName) == null) {
+                                    webappLastWatchedResourceModifiedTimes.put(contextName,
+                                            previousWatchedResourceModifiedTime);
+                                    log.warn("Restored watched-resource baseline for context: " + contextName);
+                                }
                             }
                         }
                     }
@@ -184,10 +228,6 @@ public abstract class AbstractWebappDeployer extends AbstractDeployer {
         }
 
         return latestWatchedResourceModifiedTime > knownWatchedResourceModifiedTime;
-    }
-
-    private void updateWatchedResourceModifiedState(Context context, long latestWatchedResourceModifiedTime) {
-        webappLastWatchedResourceModifiedTimes.put(context.getName(), latestWatchedResourceModifiedTime);
     }
 
     private long getLatestWatchedResourceModifiedTime(String fileName, Context context) {


### PR DESCRIPTION
### Root cause & fix
- `context.reload()` on a Carbon-managed webapp context does not re-run Jasper's TLD-scan initializer, leaving `TldCache` null → next taglib-JSP recompile throws `NullPointerException` at `JspCompilationContext.getTldResourcePath` (HTTP 500 on login until restart). Surfaces on NFS-shared, multi-node deployments where pod scale-up drifts watched-resource timestamps.
- On a watched-resource change, **undeploy + redeploy** the context instead of `context.reload()` — the full servlet-initializer chain re-runs and the `TldCache` is rebuilt naturally (no Jasper internals). Includes one redeploy retry + watched-resource baseline restore on failure.
- Gate the whole watched-resource reload behind a new `carbon.xml` property `WebappManagement.WatchedResourceReloadEnabled` (**default `true`**, legacy behavior preserved). Set `false` to disable the path entirely — these watched resources are shipped artifacts not edited at runtime, so disabling is safe and removes the trigger. JSP hot deployment is independent (Jasper) and unaffected.

### Source fix
Ported from the IS 6.1.0 support fix: wso2-support/carbon-deployment#147 (redeploy) — same approach as the customer hotfix wso2-support/carbon-deployment#146.

### Tracking issue
wso2/product-is#26547

### Testing
Verified on IS 6.1.0: `false` → no redeploy, 0 `getTldResourcePath` NPE, JSPs 200; `true` (default) → redeploy fires cleanly, 0 NPE, JSPs 200.

> Generated with assistance from Claude Code — please review carefully.

### Related PRs
- https://github.com/wso2/carbon-kernel/pull/4601