### PR TITLE
[carbon-deployment] [Revert] Jackson upgrade to 2.21.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1491,8 +1491,8 @@
 
         <org.apache.cxf.version>3.5.11</org.apache.cxf.version>
         <xercesImpl.version>2.12.2.wso2v1</xercesImpl.version>
-        <com.fasterxml.jackson.version>2.21.2</com.fasterxml.jackson.version>
-        <com.fasterxml.jackson.databind.version>2.21.2</com.fasterxml.jackson.databind.version>
+        <com.fasterxml.jackson.version>2.17.2</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.databind.version>2.17.2</com.fasterxml.jackson.databind.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 
         <!-- for maven release process -->


### PR DESCRIPTION
## Purpose
Revert the Jackson upgrade introduced in [[1]](https://github.com/wso2/carbon-deployment/pull/436).

## Goals
- Remove the dependency on `jackson-annotations 2.21.2`, which does not exist on Maven Central or WSO2 Nexus — the `jackson-annotations` artifact only releases at minor versions (e.g. `2.21`, `2.22`) with no patch suffixes
- Resolve the Jenkins build failure caused by an unresolvable `jackson-annotations:2.21.2` artifact

## Approach
- Revert `com.fasterxml.jackson.version` from `2.21.2` → `2.17.2`
- Revert `com.fasterxml.jackson.databind.version` from `2.21.2` → `2.17.2`

## Related PRs
- [1] https://github.com/wso2/carbon-deployment/pull/436